### PR TITLE
refactor(api): require explicit keyword arguments in set_value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,9 +214,6 @@ project goals tracked in our
   for automating package publishing and release management.
 - **Issue #13 (Documentation Migration)**: Create a dedicated `docs/` directory
   and import/format prior documentation and user manuals.
-- **Issue #12 (Explicit Keyword Args)**: Refactor `set_value` and constructor
-  interfaces to require explicit keyword arguments for clearer API contracts and
-  better IDE support.
 - **Issue #11 (f-strings)**: Convert remaining legacy string formatting across
   `BitVector.py` to modern f-strings.
 - **Issue #10 (Modern Random Number Generator)**: Replace default

--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -1311,17 +1311,52 @@ class BitVector:
         """
         return sum(self)
 
-    def set_value(self, *args: Any, **kwargs: Any) -> None:
+    def set_value(
+        self,
+        *,
+        filename: str | None = None,
+        fp: Any = None,
+        size: int | None = None,
+        intVal: int | None = None,
+        bitlist: Any = None,
+        bitstring: str | None = None,
+        hexstring: str | None = None,
+        textstring: str | None = None,
+        rawbytes: bytes | None = None,
+    ) -> None:
         """Reinitializes the bit vector in-place with new data.
 
         Accepts the same keyword arguments as the class constructor to overwrite
         the current vector's size and contents.
 
         Args:
-            *args: Positional arguments passed to constructor.
-            **kwargs: Keyword arguments specifying the new data source and size.
+            filename: Path to a disk file to open for streaming input.
+            fp: An open file-like stream object to read bits from.
+            size: The desired number of bits for a zero-initialized vector (or
+                used in conjunction with intVal).
+            intVal: An integer value to convert into a bit vector.
+            bitlist: A sequence or list of integers (0s and 1s) representing bits.
+            bitstring: A string of binary characters ('0's and '1's).
+            hexstring: A string of hexadecimal characters to convert to bits.
+            textstring: An ASCII or text string to convert to character bits.
+            rawbytes: A bytes object to unpack into a bit vector.
+
+        Raises:
+            ValueError: If no argument is provided, if mutually exclusive
+                arguments are specified together, or if input values are invalid.
         """
-        BitVector.__init__(self, *args, **kwargs)
+        BitVector.__init__(
+            self,
+            filename=filename,
+            fp=fp,
+            size=size,
+            intVal=intVal,
+            bitlist=bitlist,
+            bitstring=bitstring,
+            hexstring=hexstring,
+            textstring=textstring,
+            rawbytes=rawbytes,
+        )
 
     def count_bits_sparse(self) -> int:
         """Counts set bits using Brian Kernighan's algorithm for sparse vectors.

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -278,6 +278,20 @@ def test_set_value() -> None:
     assert str(bv) == "1100"
 
 
+def test_set_value_positional_args_error() -> None:
+    """Verifies that passing positional arguments to set_value raises TypeError."""
+    bv = BitVector.BitVector(intVal=7, size=16)
+    with pytest.raises(TypeError, match="takes 1 positional argument"):
+        bv.set_value(123)  # type: ignore[misc,arg-type]  # ty: ignore[too-many-positional-arguments]
+
+
+def test_set_value_invalid_keyword_error() -> None:
+    """Verifies passing unexpected keyword arguments to set_value raises TypeError."""
+    bv = BitVector.BitVector(intVal=7, size=16)
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        bv.set_value(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+
+
 @pytest.mark.parametrize(
     ("method_name", "bv1_str", "bv2_str", "err_match"),
     [


### PR DESCRIPTION
Fixes #12

## Type of Change

- [ ] Bug fix (`fix(scope): ...`)
- [ ] New feature (`feat(scope): ...`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Documentation update (`docs: ...`)
- [x] Chore / Refactor (`chore: ...` / `refactor: ...`)

## Checklist

- [x] My code follows the code style and modern Python (`>=3.13`) standards of
  this project.
- [x] I have written new/refactored tests in the **best modern `pytest` form**
  (using `assert`, fixtures, `@pytest.mark.parametrize`).
- [x] My commit messages adhere to the **Conventional Commits** specification
  and do **not** contain `TAG=` or `CONV=` entries.
- [x] All new and existing tests pass (`uv run pytest`).
- [x] Pre-commit checks pass locally (`uv run pre-commit run --all-files`).
