### PR TITLE
chore(package): set version to 0.0.1 and add semver test

### DIFF
--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-__version__ = "3.5.0"
+__version__ = "0.0.1"
 
 import array
 import binascii

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bitvector-modern"
-version = "3.5.0"
+version = "0.0.1"
 description = "A memory-efficient packed representation for bit arrays in pure Python"
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 """Tests BitVector constructors and initialization error validation."""
 
 import io
+import re
 from pathlib import Path
 from typing import Any
 
@@ -172,3 +173,15 @@ def test_intVal_zero_hex_helper() -> None:
     )
     assert bv2.size == 5
     assert str(bv2) == "00000"
+
+
+def test_version() -> None:
+    """Tests that the package version string conforms to semantic versioning."""
+    semver_pattern = (
+        r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+        r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+        r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+        r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+    )
+    assert isinstance(BitVector.__version__, str)
+    assert re.fullmatch(semver_pattern, BitVector.__version__) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "bitvector-modern"
-version = "3.5.0"
+version = "0.0.1"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Update version in pyproject.toml and BitVector.py to 0.0.1
- Synchronize uv.lock with new package version
- Add test_version in tests/test_init.py to validate semantic versioning compliance
