### PR TITLE
feat(comparison): support comparing BitVector with int and float

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,9 @@ The core functionality of `bitvector-modern` is implemented in
 - **Permutations**: Reordering bits via `permute()`, `unpermute()`, and
   `reverse()`.
 - **Comparisons & Equality**: Full rich comparison support (`==`, `!=`, `<`,
-  `<=`, `>`, `>=`) and canonical ordering (`min_canonical`).
+  `<=`, `>`, `>=`) supporting `BitVector`, `int`, and `float` operands, and
+  canonical ordering (`min_canonical`). `==` and `!=` also allow comparison with
+  other types (evaluating to `False` and `True` respectively).
 - **Conversions & Output**: Integer conversion (`int_val()`), string output
   (`get_bitvector_in_ascii()`, `get_bitvector_in_hex()`, `__str__`), and stream
   writing (`write_to_file`, `write_bits_to_stream_object`).

--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -1122,7 +1122,7 @@ class BitVector:
             return ""
         return "".join(map(str, self))
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Checks equality between this bit vector and another object.
 
         Args:
@@ -1130,18 +1130,23 @@ class BitVector:
 
         Returns:
             True if other is a BitVector of identical size and bit values,
-            otherwise False.
+            or if other is an int/float equal to the integer value of this
+            vector. Otherwise False.
         """
-        if self.size != other.size:
-            return False
-        i = 0
-        while i < self.size:
-            if self[i] != other[i]:
+        if isinstance(other, BitVector):
+            if self.size != other.size:
                 return False
-            i += 1
-        return True
+            for i in range(self.size):
+                if self[i] != other[i]:
+                    return False
+            return True
 
-    def __ne__(self, other: Any) -> bool:
+        if isinstance(other, (int, float)):
+            return self.int_val() == other
+
+        return False
+
+    def __ne__(self, other: object) -> bool:
         """Checks inequality between this bit vector and another object.
 
         Args:
@@ -1152,57 +1157,101 @@ class BitVector:
         """
         return not self == other
 
-    def __lt__(self, other: Any) -> bool:
-        """Checks if this bit vector is strictly less than another vector.
+    def __lt__(self, other: object) -> bool:
+        """Checks if this bit vector is strictly less than another object.
 
         Comparison is performed by evaluating integer values.
 
         Args:
-            other: The BitVector instance to compare against.
+            other: The BitVector, int, or float instance to compare against.
 
         Returns:
             True if this vector's integer value is less than other's.
-        """
-        return self.int_val() < other.int_val()
 
-    def __le__(self, other: Any) -> bool:
-        """Checks if this bit vector is less than or equal to another vector.
+        Raises:
+            TypeError: If other is not a BitVector, int, or float.
+        """
+        if isinstance(other, BitVector):
+            return self.int_val() < other.int_val()
+
+        if isinstance(other, (int, float)):
+            return self.int_val() < other
+
+        raise TypeError(
+            f"'<' not supported between instances of 'BitVector' and '{type(other).__name__}'"
+        )
+
+    def __le__(self, other: object) -> bool:
+        """Checks if this bit vector is less than or equal to another object.
 
         Comparison is performed by evaluating integer values.
 
         Args:
-            other: The BitVector instance to compare against.
+            other: The BitVector, int, or float instance to compare against.
 
         Returns:
             True if this vector's integer value is less than or equal to other's.
-        """
-        return self.int_val() <= other.int_val()
 
-    def __gt__(self, other: Any) -> bool:
-        """Checks if this bit vector is strictly greater than another vector.
+        Raises:
+            TypeError: If other is not a BitVector, int, or float.
+        """
+        if isinstance(other, BitVector):
+            return self.int_val() <= other.int_val()
+
+        if isinstance(other, (int, float)):
+            return self.int_val() <= other
+
+        raise TypeError(
+            f"'<=' not supported between instances of 'BitVector' and '{type(other).__name__}'"
+        )
+
+    def __gt__(self, other: object) -> bool:
+        """Checks if this bit vector is strictly greater than another object.
 
         Comparison is performed by evaluating integer values.
 
         Args:
-            other: The BitVector instance to compare against.
+            other: The BitVector, int, or float instance to compare against.
 
         Returns:
             True if this vector's integer value is greater than other's.
-        """
-        return self.int_val() > other.int_val()
 
-    def __ge__(self, other: Any) -> bool:
-        """Checks if this bit vector is greater than or equal to another vector.
+        Raises:
+            TypeError: If other is not a BitVector, int, or float.
+        """
+        if isinstance(other, BitVector):
+            return self.int_val() > other.int_val()
+
+        if isinstance(other, (int, float)):
+            return self.int_val() > other
+
+        raise TypeError(
+            f"'>' not supported between instances of 'BitVector' and '{type(other).__name__}'"
+        )
+
+    def __ge__(self, other: object) -> bool:
+        """Checks if this bit vector is greater than or equal to another object.
 
         Comparison is performed by evaluating integer values.
 
         Args:
-            other: The BitVector instance to compare against.
+            other: The BitVector, int, or float instance to compare against.
 
         Returns:
             True if this vector's integer value is greater than or equal to other's.
+
+        Raises:
+            TypeError: If other is not a BitVector, int, or float.
         """
-        return self.int_val() >= other.int_val()
+        if isinstance(other, BitVector):
+            return self.int_val() >= other.int_val()
+
+        if isinstance(other, (int, float)):
+            return self.int_val() >= other
+
+        raise TypeError(
+            f"'>=' not supported between instances of 'BitVector' and '{type(other).__name__}'"
+        )
 
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> Self:
         """Creates a deep copy of the bit vector for the copy module.

--- a/tests/test_comparison_ops.py
+++ b/tests/test_comparison_ops.py
@@ -80,3 +80,60 @@ def test_comparison_operators(
     right: BitVector.BitVector = request.getfixturevalue(right_name)
     compare_func = OP_MAP[op]
     assert compare_func(left, right) is expected
+
+
+@pytest.mark.parametrize(
+    ("bv_val", "other", "op", "expected"),
+    [
+        (51, 51, "==", True),
+        (51, 52, "==", False),
+        (51, 51, "!=", False),
+        (51, 52, "!=", True),
+        (51, 52, "<", True),
+        (51, 51, "<=", True),
+        (51, 50, ">", True),
+        (51, 51, ">=", True),
+        # Float comparisons
+        (51, 51.0, "==", True),
+        (51, 51.5, "==", False),
+        (51, 51.0, "!=", False),
+        (51, 51.5, "!=", True),
+        (51, 52.0, "<", True),
+        (51, 51.0, "<=", True),
+        (51, 50.0, ">", True),
+        (51, 51.0, ">=", True),
+    ],
+)
+def test_comparison_with_numeric_types(
+    bv_val: int, other: int | float, op: ComparisonOp, expected: bool
+) -> None:
+    """Tests comparisons between BitVector and int/float."""
+    bv = BitVector.BitVector(intVal=bv_val)
+    compare_func = OP_MAP[op]
+    assert compare_func(bv, other) is expected
+
+
+def test_eq_ne_with_unsupported_types() -> None:
+    """Tests that == and != work with any type and don't raise TypeError."""
+    bv = BitVector.BitVector(intVal=51)
+    assert (bv == "hello") is False
+    assert (bv != "hello") is True
+    assert (bv == [51]) is False
+    assert (bv != [51]) is True
+    assert (bv == None) is False  # noqa: E711
+    assert (bv != None) is True  # noqa: E711
+
+
+@pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
+def test_order_comparisons_with_unsupported_types_raise_type_error(
+    op: ComparisonOp,
+) -> None:
+    """Tests that <, <=, >, and >= raise TypeError for unsupported types."""
+    bv = BitVector.BitVector(intVal=51)
+    compare_func = OP_MAP[op]
+    with pytest.raises(TypeError):
+        compare_func(bv, "hello")
+    with pytest.raises(TypeError):
+        compare_func(bv, [51])
+    with pytest.raises(TypeError):
+        compare_func(bv, None)


### PR DESCRIPTION
Convert comparison dunder operations 'other' argument to 'object' type. Allow the operators to work with other being of type BitVector, int, or float.

For `__eq__` and `__ne__` allow comparison with other types (evaluating to `False` and `True` respectively). For the rest, raise a `TypeError`.

Add tests in tests/test_comparison_ops.py and update AGENTS.md.

This is a partial implementation of issue #8 (Tighten Type Annotations).