### PR TITLE
docs: add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+# Code of Conduct
+
+This code of conduct governs how we behave in any project forum or event and
+whenever we will be judged by our actions. We expect it to be honored by
+everyone who participates in the `bitvector-modern` community formally or
+informally.
+
+This code of conduct is adapted from the [OSGeo Code of Conduct
+Version 1.0](https://www.osgeo.org/resources/osgeo-code-of-conduct/).
+
+## Introduction
+
+This code of conduct governs how we behave in any project forum or event and
+whenever we will be judged by our actions. We expect it to be honored by
+everyone who participates in our community formally or informally.
+
+It applies to in-person events (such as conferences and related social events),
+public and private mailing lists, the issue tracker, the wiki, blogs, Twitter,
+and any other forums which the community uses for communication and
+interactions.
+
+This code is not exhaustive or complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. We expect it to
+be followed in spirit as much as in the letter, so that it can enrich all of us
+and the technical communities in which we participate.
+
+## Diversity Statement
+
+We welcome and encourage participation by everyone. We are committed to being a
+community that everyone feels good about joining, and we will always work to
+treat everyone well. No matter how you identify yourself or how others perceive
+you: we welcome you.
+
+## Specific Guidelines
+
+We strive to:
+
+*   **Be open.** We invite anyone to participate in our community. We preferably
+    use public methods of communication for project-related messages, unless
+    discussing something sensitive. This applies to messages for help or
+    project-related support, too; not only is a public support request much more
+    likely to result in an answer to a question, it also makes sure that any
+    inadvertent mistakes made by people answering will be more easily detected
+    and corrected.
+*   **Be empathetic, welcoming, friendly, and patient.** We work together to
+    resolve conflict, assume good intentions, and do our best to act in an
+    empathetic fashion. We may all experience some frustration from time to
+    time, but we do not allow frustration to turn into a personal attack. A
+    community where people feel uncomfortable or threatened is not a productive
+    one. Note that we have a multi-cultural, multi-lingual community and some of
+    us are non-native speakers. We should be respectful when dealing with other
+    community members as well as with people outside our community.
+*   **Be collaborative.** Our work will be used by other people, and in turn we
+    will depend on the work of others. When we make something for the benefit of
+    the project, we are willing to explain to others how it works, so that they
+    can build on the work to make it even better. Any decision we make will
+    affect users and colleagues, and we take those consequences seriously when
+    making decisions.
+*   **Be inquisitive.** Nobody knows everything! Asking questions early avoids
+    many problems later, so questions are encouraged, though they may be
+    directed to the appropriate forum. Those who are asked should be responsive
+    and helpful, within the context of our shared goal of improving the project.
+*   **Be careful in the words that we choose.** Whether we are participating as
+    professionals or volunteers, we value professionalism in all interactions,
+    and take responsibility for our own speech. Be kind to others. Do not insult
+    or put down other participants.
+*   **Be concise.** Keep in mind that what you write once will be read by
+    hundreds of persons. Writing a short email means people can understand the
+    conversation as efficiently as possible. Short emails should always strive
+    to be empathetic, welcoming, friendly and patient. When a long explanation
+    is necessary, consider adding a summary.
+*   Try to bring new ideas to a conversation so that each mail adds something
+    unique to the thread, keeping in mind that the rest of the thread still
+    contains the other messages with arguments that have already been made.
+*   Try to stay on topic, especially in discussions that are already fairly
+    large.
+*   **Step down considerately.** Members of every project come and go. When
+    somebody leaves or disengages from the project they should tell people they
+    are leaving and take the proper steps to ensure that others can pick up
+    where they left off. In doing so, they should remain respectful of those who
+    continue to participate in the project and should not misrepresent the
+    project's goals or achievements. Likewise, community members should respect
+    any individual's choice to leave the project.
+
+## Anti-Harassment
+
+Harassment and other exclusionary behaviour are not acceptable. This includes,
+but is not limited to:
+
+*   Personal insults or discriminatory jokes and language, especially those
+    using racist or sexist terms.
+*   Offensive comments, excessive or unnecessary profanity.
+*   Intimidation, violent threats or demands.
+*   Sustained disruption of sessions or events.
+*   Stalking, harassing photography or recording.
+*   Unwelcome physical contact or sexual attention.
+*   Repeated harassment of others. In general, if someone asks you to stop, then
+    stop.
+*   Posting (or threatening to post) other people's personally identifying
+    information ("doxing").
+*   Sharing private content, such as emails sent privately or non-publicly, or
+    unlogged forums such as IRC channel history.
+*   Advocating for, or encouraging, any of the above behaviour.
+
+## Reporting Guidelines
+
+If you believe someone is breaking this code of conduct, you may reply to them,
+and point to this code of conduct. Such messages may be in public or in private,
+whatever is most appropriate. Assume good faith; it is more likely that
+participants are unaware of their bad behaviour than that they intentionally try
+to degrade the quality of the discussion. Should there be difficulties in
+dealing with the situation, you may report your concerns to project
+maintainers. Serious or persistent offenders may be expelled from project forums
+or repositories.
+
+To report violations privately, contact the project maintainers directly.
+
+## Application
+
+Contributors to `bitvector-modern` are expected to act respectfully toward
+others in accordance with the [OSGeo Code of
+Conduct](https://www.osgeo.org/code_of_conduct/).


### PR DESCRIPTION
- Add CODE_OF_CONDUCT.md at the repository root.
- Adapt the text from the OSGeo Code of Conduct Version 1.0.
- Reference OSGeo source and guidelines in the document.
