### PR TITLE
refactor: convert asserts to ValueErrors and add bandit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,12 @@ repos:
     hooks:
       - id: zizmor
 
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.2
+    hooks:
+      - id: bandit
+        exclude: ^tests/
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:

--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -54,7 +54,8 @@ def _readblock(blocksize: int, bitvector: BitVector) -> str:
         A string of binary characters ('0's and '1's) representing the read
         bits, up to blocksize in length.
     """
-    assert bitvector.FILEIN is not None
+    if bitvector.FILEIN is None:
+        raise ValueError("FILEIN must not be None")
 
     bitstring = ""
     i = 0
@@ -1442,14 +1443,14 @@ class BitVector:
             A floating-point coefficient between 0.0 and 1.0.
 
         Raises:
-            AssertionError: If vectors are of unequal length or both zero.
+            ValueError: If vectors are of unequal length or both zero.
         """
-        assert self.int_val() > 0 or other.int_val() > 0, (
-            "Jaccard called on two zero vectors --- NOT ALLOWED"
-        )
-        assert self.size == other.size, (
-            "bitvectors for comparing with Jaccard must be of equal length"
-        )
+        if self.int_val() == 0 and other.int_val() == 0:
+            raise ValueError("Jaccard called on two zero vectors --- NOT ALLOWED")
+        if self.size != other.size:
+            raise ValueError(
+                "bitvectors for comparing with Jaccard must be of equal length"
+            )
         intersect = self & other
         union = self | other
         return intersect.count_bits_sparse() / float(union.count_bits_sparse())
@@ -1464,9 +1465,10 @@ class BitVector:
             A floating-point distance between 0.0 and 1.0 (1 - similarity).
 
         Raises:
-            AssertionError: If vectors are of unequal length.
+            ValueError: If vectors are of unequal length.
         """
-        assert self.size == other.size, "vectors of unequal length"
+        if self.size != other.size:
+            raise ValueError("vectors of unequal length")
         return 1 - self.jaccard_similarity(other)
 
     def hamming_distance(self, other: BitVector) -> int:
@@ -1479,9 +1481,10 @@ class BitVector:
             The integer number of bit positions where the two vectors disagree.
 
         Raises:
-            AssertionError: If vectors are of unequal length.
+            ValueError: If vectors are of unequal length.
         """
-        assert self.size == other.size, "vectors of unequal length"
+        if self.size != other.size:
+            raise ValueError("vectors of unequal length")
         diff = self ^ other
         return diff.count_bits_sparse()
 
@@ -1495,9 +1498,10 @@ class BitVector:
             The integer index of the next set bit (1), or -1 if none is found.
 
         Raises:
-            AssertionError: If from_index is negative.
+            ValueError: If from_index is negative.
         """
-        assert from_index >= 0, "from_index must be nonnegative"
+        if from_index < 0:
+            raise ValueError("from_index must be nonnegative")
         i = from_index
         v = self.vector
         vec_len = len(v)
@@ -1530,9 +1534,10 @@ class BitVector:
             The total number of set bits from index 0 up to position (inclusive).
 
         Raises:
-            AssertionError: If the bit at position is not set to 1.
+            ValueError: If the bit at position is not set to 1.
         """
-        assert self[position] == 1, "the arg bit not set"
+        if self[position] != 1:
+            raise ValueError("the arg bit not set")
         bv = self[0 : position + 1]
         return bv.count_bits()
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -304,7 +304,7 @@ def test_set_value_invalid_keyword_error() -> None:
 def test_distance_metrics_raise_error(
     method_name: str, bv1_str: str, bv2_str: str, err_match: str
 ) -> None:
-    """Verifies distance metrics raise AssertionError on invalid inputs.
+    """Verifies distance metrics raise ValueError on invalid inputs.
 
     Args:
         method_name: Metric method name ('jaccard_similarity', etc.).
@@ -315,7 +315,7 @@ def test_distance_metrics_raise_error(
     bv1 = BitVector.BitVector(bitstring=bv1_str)
     bv2 = BitVector.BitVector(bitstring=bv2_str)
     method = getattr(bv1, method_name)
-    with pytest.raises(AssertionError, match=err_match):
+    with pytest.raises(ValueError, match=err_match):
         method(bv2)
 
 
@@ -349,9 +349,9 @@ def test_distance_metrics(
 
 
 def test_next_set_bit_raises_error() -> None:
-    """Verifies calling next_set_bit with a negative index raises AssertionError."""
+    """Verifies calling next_set_bit with a negative index raises ValueError."""
     bv = BitVector.BitVector(bitstring="00000000000001")
-    with pytest.raises(AssertionError, match="from_index must be nonnegative"):
+    with pytest.raises(ValueError, match="from_index must be nonnegative"):
         bv.next_set_bit(-1)
 
 
@@ -376,9 +376,9 @@ def test_next_set_bit(bitstring: str, start_idx: int, expected_idx: int) -> None
 
 
 def test_rank_of_bit_set_at_index_raises_error() -> None:
-    """Verifies rank query on an unset bit raises AssertionError."""
+    """Verifies rank query on an unset bit raises ValueError."""
     bv = BitVector.BitVector(bitstring="01010101011100")
-    with pytest.raises(AssertionError, match="the arg bit not set"):
+    with pytest.raises(ValueError, match="the arg bit not set"):
         bv.rank_of_bit_set_at_index(0)
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -131,3 +131,18 @@ def test_close_file_object(tmp_path: Path) -> None:
     assert bv.FILEIN.closed is False
     bv.close_file_object()
     assert bv.FILEIN.closed is True
+
+
+def test_read_bits_from_file_none_filein(tmp_path: Path) -> None:
+    """Verifies that reading from a file when FILEIN is None raises ValueError.
+
+    Args:
+        tmp_path: Pytest temporary directory path fixture.
+    """
+    file_path = tmp_path / "test_none_filein.bin"
+    file_path.write_bytes(b"test")
+    bv = BitVector.BitVector(filename=str(file_path))
+    bv.close_file_object()
+    bv.FILEIN = None
+    with pytest.raises(ValueError, match="FILEIN must not be None"):
+        bv.read_bits_from_file(8)


### PR DESCRIPTION
Add bandit to pre-commit to catch assert usage. Convert asserts in BitVector.py to raise ValueError and update tests to expect ValueError. Add test for FILEIN is None case.

Fixes 38
