### PR TITLE
ci(github): configure PyPI secret token for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           path: dist/
           if-no-files-found: error
 
+  # zizmor: ignore[use-trusted-publishing]
   publish-pypi:
     name: Publish to PyPI
     needs: build
@@ -64,7 +65,6 @@ jobs:
       name: pypi
       url: https://pypi.org/p/bitvector-modern
     permissions:
-      id-token: write
       contents: read
     steps:
       - name: Download artifacts
@@ -75,6 +75,9 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          # zizmor: ignore[use-trusted-publishing]
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
   github-release:
     name: Create GitHub Release


### PR DESCRIPTION
Update publish-pypi job in release.yml to authenticate using secrets.PYPI_API_TOKEN.

For #16 