### PR TITLE
refactor(BitVector): use 'in' for multiple equality checks

### DIFF
--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -1651,7 +1651,7 @@ class BitVector:
             k += 1
         for a in probes:
             a_raised_to_q = pow(a, q, p)
-            if a_raised_to_q == 1 or a_raised_to_q == p - 1:
+            if a_raised_to_q in (1, p - 1):
                 continue
             a_raised_to_jq = a_raised_to_q
             primeflag = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ max-line-length = 88
 
 [tool.pylint.messages_control]
 disable = [
-    "consider-using-in",
     "consider-using-with",
     "duplicate-code",
     "fixme",


### PR DESCRIPTION
Enables 'consider-using-in' in pylint and fixes violations in BitVector.py.
