### PR TITLE
refactor(lint): enable pylint unexpected-keyword-arg globally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ dist/
 *.egg
 .eggs/
 
+# Test artifacts
+test.txt
+testinput*.txt
+
 # Coverage
 .benchmarks/
 .coverage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,5 +127,4 @@ disable = [
     "too-many-public-methods",
     "too-many-return-statements",
     "too-many-statements",
-    "unexpected-keyword-arg",
 ]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -29,6 +29,7 @@ def test_positional_args_error() -> None:
 def test_invalid_keyword_error() -> None:
     """Verifies passing unexpected keyword arguments raises TypeError."""
     with pytest.raises(TypeError, match="unexpected keyword argument"):
+        # pylint: disable-next=unexpected-keyword-arg
         BitVector.BitVector(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -289,6 +289,7 @@ def test_set_value_invalid_keyword_error() -> None:
     """Verifies passing unexpected keyword arguments to set_value raises TypeError."""
     bv = BitVector.BitVector(intVal=7, size=16)
     with pytest.raises(TypeError, match="unexpected keyword argument"):
+        # pylint: disable-next=unexpected-keyword-arg
         bv.set_value(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
 


### PR DESCRIPTION
Enable pylint's unexpected-keyword-arg check globally in pyproject.toml and add targeted inline pylint disables to negative test cases in test_init.py and test_operations.py. Also update .gitignore to ignore test artifacts test.txt and testinput*.txt.
