### PR TITLE
docs(pylint): add missing class docstrings for BitVector and BitVectorProtocol

### DIFF
--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -41,6 +41,16 @@ ARRAY_TYPE = "Q"
 
 
 class BitVector:
+    """A memory-efficient packed representation of bit arrays and bit vectors.
+
+    Uses `array.array('Q')` unsigned integers for compact bitwise storage,
+    manipulation, boolean logic, shifts, rotations, and GF(2^n) arithmetic.
+
+    Attributes:
+        vector: Underlying array storing packed integer words.
+        FILEOUT: Output stream object for file writing, if assigned.
+    """
+
     __slots__ = ("_size", "FILEOUT", "vector")
     _size: int
     FILEOUT: BinaryIO | None

--- a/BitVector/protocol.py
+++ b/BitVector/protocol.py
@@ -8,6 +8,12 @@ from typing import Any, Iterator, Protocol, Self
 
 
 class BitVectorProtocol(Protocol):
+    """Protocol defining the structural typing interface for BitVector instances.
+
+    Attributes:
+        size: Total number of bits in the vector.
+    """
+
     size: int
 
     def __xor__(self, other: Self) -> Self: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ disable = [
     "inconsistent-return-statements",
     "invalid-name",
     "line-too-long",
-    "missing-class-docstring",
     "missing-function-docstring",
     "protected-access",
     "too-many-arguments",


### PR DESCRIPTION
Add Google-style class docstrings to BitVector and BitVectorProtocol, and remove missing-class-docstring from Pylint's global disable list in pyproject.toml.
