### PR TITLE
refactor(init): remove legacy intVal, bitstring, and rawbytes constructor arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,7 @@ The core functionality of `bitvector-modern` is implemented in
 
 ### Constructors & Data Input (`__init__`)
 
-- Supports flexible keyword arguments: `size`, `intVal`, `bitstring`, `bitlist`,
-  `textstring`, `rawbytes`, `filename`, and `fp`.
+- Supports keyword arguments: `size` and `bitlist`.
 - **Factory Methods**: Can be initialized from an integer (`from_int`), raw
   bytes (`from_bytes`), a binary string (`from_bitstring`), a sequence of bits
   (`from_bitlist`), a string (`from_string`), or a hex string (`from_hex`).

--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -61,97 +61,41 @@ class BitVector:
         self,
         *,
         size: int | None = None,
-        intVal: int | None = None,
         bitlist: Any = None,
-        bitstring: str | None = None,
-        rawbytes: bytes | None = None,
     ) -> None:
-        """Initializes a BitVector instance from one of several possible input sources.
+        """Initializes a BitVector instance.
 
-        You must specify exactly one keyword argument to determine the data
-        source and size of the bit vector (except 'size' which may accompany 'intVal').
-        Providing multiple data source arguments will raise a ValueError.
+        You must specify either a 'size' for a zero-initialized vector or a 'bitlist'
+        containing a sequence of bits (0s and 1s). Specifying both or neither will
+        raise a ValueError.
 
         Args:
-            size: The desired number of bits for a zero-initialized vector (or
-                used in conjunction with intVal).
-            intVal: An integer value to convert into a bit vector.
+            size: The desired number of bits for a zero-initialized vector.
             bitlist: A sequence or list of integers (0s and 1s) representing bits.
-            bitstring: A string of binary characters ('0's and '1's).
-            rawbytes: A bytes object to unpack into a bit vector.
 
         Raises:
             ValueError: If no argument is provided, if mutually exclusive
                 arguments are specified together, or if input values are invalid.
         """
         self._size = 0
-        if intVal is not None:
-            if bitlist is not None or bitstring is not None or rawbytes is not None:
+        if size is not None and size >= 0:
+            if bitlist is not None:
                 raise ValueError(
-                    "When intVal is specified, you can only give a "
-                    "value to the 'size' constructor arg"
-                )
-            bv = self.from_int(intVal, size=size)
-            self._size = bv._size
-            self.vector = bv.vector
-        elif size is not None and size >= 0:
-            if (
-                intVal is not None
-                or bitlist is not None
-                or bitstring is not None
-                or rawbytes is not None
-            ):
-                raise ValueError(
-                    "When size is specified (without an intVal), you cannot "
-                    "give values to any other constructor args"
+                    "When size is specified, you cannot give values to any other constructor args"
                 )
             self._size = size
             eight_byte_ints_needed = (size + 63) // 64
             self.vector = array.array(ARRAY_TYPE, [0] * eight_byte_ints_needed)
-        elif bitstring is not None:
-            if (
-                size is not None
-                or intVal is not None
-                or bitlist is not None
-                or rawbytes is not None
-            ):
-                raise ValueError(
-                    "When a bitstring is specified, you cannot give "
-                    "values to any other constructor args"
-                )
-            bv = self.from_bitstring(bitstring)
-            self._size = bv._size
-            self.vector = bv.vector
         elif bitlist is not None:
-            if (
-                size is not None
-                or intVal is not None
-                or bitstring is not None
-                or rawbytes is not None
-            ):
+            if size is not None:
                 raise ValueError(
-                    "When bits are specified, you cannot give values "
-                    "to any other constructor args"
+                    "When bits are specified, you cannot give values to any other constructor args"
                 )
             self._size = len(bitlist)
             eight_byte_ints_needed = (len(bitlist) + 63) // 64
             self.vector = array.array(ARRAY_TYPE, [0] * eight_byte_ints_needed)
             for idx, bit in enumerate(bitlist):
                 self[idx] = bit
-        elif rawbytes is not None:
-            if (
-                size is not None
-                or intVal is not None
-                or bitlist is not None
-                or bitstring is not None
-            ):
-                raise ValueError(
-                    "When bits are specified through rawbytes, you "
-                    "cannot give values to any other constructor args"
-                )
-            bv = self.from_bytes(rawbytes)
-            self._size = bv._size
-            self.vector = bv.vector
         else:
             raise ValueError("wrong arg(s) for constructor")
 
@@ -351,9 +295,9 @@ class BitVector:
                 slicebits.append(self[x])
             return BitVector(bitlist=slicebits)
         if self._size == 0:
-            return BitVector(bitstring="")
+            return BitVector.from_bitstring("")
         if i == j:
-            return BitVector(bitstring="")
+            return BitVector.from_bitstring("")
         for x in range(i, j):
             slicebits.append(self[x])
         return BitVector(bitlist=slicebits)
@@ -472,7 +416,7 @@ class BitVector:
             new_bv.vector.frombytes(self.vector.tobytes())
         else:
             out_str = str(self) + str(other)
-            return self.__class__(bitstring=out_str)
+            return self.__class__.from_bitstring(out_str)
         new_bv._size = self._size
         new_bv += other
         return new_bv
@@ -1428,10 +1372,7 @@ class BitVector:
         self,
         *,
         size: int | None = None,
-        intVal: int | None = None,
         bitlist: Any = None,
-        bitstring: str | None = None,
-        rawbytes: bytes | None = None,
     ) -> None:
         """Reinitializes the bit vector in-place with new data.
 
@@ -1439,12 +1380,8 @@ class BitVector:
         the current vector's size and contents.
 
         Args:
-            size: The desired number of bits for a zero-initialized vector (or
-                used in conjunction with intVal).
-            intVal: An integer value to convert into a bit vector.
+            size: The desired number of bits for a zero-initialized vector.
             bitlist: A sequence or list of integers (0s and 1s) representing bits.
-            bitstring: A string of binary characters ('0's and '1's).
-            rawbytes: A bytes object to unpack into a bit vector.
 
         Raises:
             ValueError: If no argument is provided, if mutually exclusive
@@ -1453,10 +1390,7 @@ class BitVector:
         BitVector.__init__(
             self,
             size=size,
-            intVal=intVal,
             bitlist=bitlist,
-            bitstring=bitstring,
-            rawbytes=rawbytes,
         )
 
     def count_bits_sparse(self) -> int:
@@ -1585,7 +1519,7 @@ class BitVector:
         """
         if int(self) == 0:
             return False
-        bv = self & BitVector(intVal=int(self) - 1)
+        bv = self & BitVector.from_int(int(self) - 1)
         if int(bv) == 0:
             return True
         return False
@@ -1627,7 +1561,7 @@ class BitVector:
             a, b = b, a
         while b != 0:
             a, b = b, a % b
-        return self.__class__(intVal=a)
+        return self.__class__.from_int(a)
 
     def multiplicative_inverse(self, modulus: BitVector) -> Self | None:
         """Calculates the modular multiplicative inverse using integer arithmetic.
@@ -1655,7 +1589,7 @@ class BitVector:
             return None
 
         MI = (x_old + MOD) % MOD
-        return self.__class__(intVal=MI)
+        return self.__class__.from_int(MI)
 
     def gf_multiply(self, b: BitVector) -> Self:
         """Multiplies two polynomials in Galois Field GF(2).
@@ -1695,7 +1629,7 @@ class BitVector:
         num = self
         if len(mod) > n + 1:
             raise ValueError("Modulus bit pattern too long")
-        quotient = self.__class__(intVal=0, size=len(num))
+        quotient = self.__class__.from_int(0, size=len(num))
         remainder = copy.deepcopy(num)
         i = 0
         while 1:
@@ -1753,8 +1687,8 @@ class BitVector:
         NUM = copy.deepcopy(num)
         MOD = copy.deepcopy(mod)
         x = self.__class__(size=len(mod))
-        x_old = self.__class__(intVal=1, size=len(mod))
-        y = self.__class__(intVal=1, size=len(mod))
+        x_old = self.__class__.from_int(1, size=len(mod))
+        y = self.__class__.from_int(1, size=len(mod))
         y_old = self.__class__(size=len(mod))
         while int(mod):
             quotient, remainder = num.gf_divide_by_modulus(mod, n)
@@ -1851,7 +1785,7 @@ class BitVector:
         candidate |= 1
         candidate |= 1 << width - 1
         candidate |= 2 << width - 3
-        return self.__class__(intVal=candidate)
+        return self.__class__.from_int(candidate)
 
     def min_canonical(self) -> Self:
         """Finds the minimum canonical circular rotation of the bit vector.
@@ -1863,4 +1797,4 @@ class BitVector:
             A new BitVector instance representing the minimum canonical rotation.
         """
         intvals_for_circular_shifts = [int(self << i) for i in range(len(self))]
-        return self.__class__(intVal=min(intvals_for_circular_shifts), size=len(self))
+        return self.__class__.from_int(min(intvals_for_circular_shifts), size=len(self))

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -36,20 +36,20 @@ bv = BitVector(bitlist=[1, 1, 0, 1])
 print(bv)  # 1101
 
 # Construct a bit vector from an integer
-bv = BitVector(intVal=5678)
+bv = BitVector.from_int(5678)
 print("\nBit vector constructed from integer 5678:")
 print(bv)  # 1011000101110
 print("\nBit vector constructed from integer 0:")
-bv = BitVector(intVal=0)
+bv = BitVector.from_int(0)
 print(bv)  # 0
 print("\nBit vector constructed from integer 2:")
-bv = BitVector(intVal=2)
+bv = BitVector.from_int(2)
 print(bv)  # 10
 print("\nBit vector constructed from integer 3:")
-bv = BitVector(intVal=3)
+bv = BitVector.from_int(3)
 print(bv)  # 11
 print("\nBit vector constructed from integer 123456:")
-bv = BitVector(intVal=123456)
+bv = BitVector.from_int(123456)
 print(bv)  # 11110001001000000
 print("\nInt value of the previous bit vector as computed by int():")
 print(int(bv))  # 123456
@@ -58,7 +58,7 @@ print(int(bv))  # 123456
 
 # Construct a bit vector from a very large integer:
 x = 12345678901234567890123456789012345678901234567890123456789012345678901234567890
-bv = BitVector(intVal=x)
+bv = BitVector.from_int(x)
 print("\nHere is a bit vector constructed from a very large integer:")
 print(bv)
 print(f"The integer value of the above bit vector is:{int(bv)}")
@@ -70,11 +70,11 @@ print("\nBit vector constructed directly from a file like object:")
 print(bv)  # 111100001111
 
 # Construct a bit vector directly from a bit string:
-bv = BitVector(bitstring="00110011")
+bv = BitVector.from_bitstring("00110011")
 print("\nBit Vector constructed directly from a bit string:")
 print(bv)  # 00110011
 
-bv = BitVector(bitstring="")
+bv = BitVector.from_bitstring("")
 print("\nBit Vector constructed directly from an empty bit string:")
 print(bv)  # nothing
 print("\nInteger value of the previous bit vector:")
@@ -117,18 +117,18 @@ print(
 )
 mypubkey = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA5amriY96HQS8Y/nKc8zu3zOylvpOn3vzMmWwrtyDy+aBvns4UC1RXoaD9rDKqNNMCBAQwWDsYwCAFsrBzbxRQONHePX8lRWgM87MseWGlu6WPzWGiJMclTAO9CTknplG9wlNzLQBj3dP1M895iLF6jvJ7GR+V3CRU6UUbMmRvgPcsfv6ec9RRPm/B8ftUuQICL0jt4tKdPG45PBJUylHs71FuE9FJNp01hrj1EMFObNTcsy9zuis0YPyzArTYSOUsGglleExAQYi7iLh17pAa+y6fZrGLsptgqryuftN9Q4NqPuTiFjlqRowCDU7sSxKDgU7bzhshyVx3+pzXO4D2Q== kak@pixie"
 keydata = base64.b64decode(bytes(mypubkey.split(None)[1], "utf-8"))
-bv = BitVector(rawbytes=keydata)
+bv = BitVector.from_bytes(keydata)
 print(bv)
 
 # Test array-like indexing for a bit vector:
-bv = BitVector(bitstring="110001")
+bv = BitVector.from_bitstring("110001")
 print("\nPrints out bits individually from bitstring 110001:")
 print(bv[0], bv[1], bv[2], bv[3], bv[4], bv[5])  # 1 1 0 0 0 1
 print("\nSame as above but using negative array indexing:")
 print(bv[-1], bv[-2], bv[-3], bv[-4], bv[-5], bv[-6])  # 1 0 0 0 1 1
 
 # Test setting bit values with positive and negative accessors:
-bv = BitVector(bitstring="1111")
+bv = BitVector.from_bitstring("1111")
 print("\nBitstring for 1111:")
 print(bv)  # 1111
 
@@ -145,13 +145,13 @@ bv[-4] = 1
 print(bv)  # 1011
 
 print("\nCheck equality and inequality ops:")
-bv1 = BitVector(bitstring="00110011")
+bv1 = BitVector.from_bitstring("00110011")
 bv2 = BitVector(bitlist=[0, 0, 1, 1, 0, 0, 1, 1])
 print(bv1 == bv2)  # True
 print(bv1 != bv2)  # False
 print(bv1 < bv2)  # False
 print(bv1 <= bv2)  # True
-bv3 = BitVector(intVal=5678)
+bv3 = BitVector.from_int(5678)
 print(int(bv3))  # 5678
 print(bv3)  # 1011000101110
 print(bv1 == bv3)  # False
@@ -183,13 +183,13 @@ bv7 = bv5 | bv6
 print(bv7)  # 1111111111111111111
 
 print("\nTry logical operations on bit vectors of different sizes:")
-print(BitVector(intVal=6) ^ BitVector(intVal=13))  # 1011
-print(BitVector(intVal=6) & BitVector(intVal=13))  # 0100
-print(BitVector(intVal=6) | BitVector(intVal=13))  # 1111
+print(BitVector.from_int(6) ^ BitVector.from_int(13))  # 1011
+print(BitVector.from_int(6) & BitVector.from_int(13))  # 0100
+print(BitVector.from_int(6) | BitVector.from_int(13))  # 1111
 
-print(BitVector(intVal=1) ^ BitVector(intVal=13))  # 1100
-print(BitVector(intVal=1) & BitVector(intVal=13))  # 0001
-print(BitVector(intVal=1) | BitVector(intVal=13))  # 1101
+print(BitVector.from_int(1) ^ BitVector.from_int(13))  # 1100
+print(BitVector.from_int(1) & BitVector.from_int(13))  # 0001
+print(BitVector.from_int(1) | BitVector.from_int(13))  # 1101
 
 print("\nExperiments with setbit() and len():")
 bv7[7] = 0
@@ -229,7 +229,7 @@ print(
     "\nExperiment with writing an internally generated bit vector out to a disk file:"
 )
 # bv1 = BitVector( bitstring = '00001010' )
-bv1 = BitVector(bitstring="11100111")
+bv1 = BitVector.from_bitstring("11100111")
 with open("test.txt", "wb") as FILEOUT:
     bv1.write_to_file(FILEOUT)
 
@@ -421,7 +421,7 @@ for bit in bv4:
     print(bit)  # 0 0 1 0 0 1 0 0 0 0 0 0 1 1 0 1 0
 
 print("\nDemonstrate padding a bit vector from left:")
-bv = BitVector(bitstring="101010")
+bv = BitVector.from_bitstring("101010")
 bv.pad_from_left(4)
 print(bv)  # 0000101010
 
@@ -431,8 +431,8 @@ print(bv)  # 00001010100000
 
 print("\nTest the syntax 'if bit_vector_1 in bit_vector_2' syntax:")
 try:
-    bv1 = BitVector(bitstring="0011001100")
-    bv2 = BitVector(bitstring="110011")
+    bv1 = BitVector.from_bitstring("0011001100")
+    bv2 = BitVector.from_bitstring("110011")
     if bv2 in bv1:
         print(f"{bv2} is in {bv1}")
     else:
@@ -443,17 +443,17 @@ except ValueError as arg:
 print(
     "\nTest the size modifier when a bit vector is initialized with the intVal method:"
 )
-bv = BitVector(intVal=45, size=16)
+bv = BitVector.from_int(45, size=16)
 print(bv)  # 0000000000101101
-bv = BitVector(intVal=0, size=8)
+bv = BitVector.from_int(0, size=8)
 print(bv)  # 00000000
-bv = BitVector(intVal=1, size=8)
+bv = BitVector.from_int(1, size=8)
 print(bv)  # 00000001
 
 print("\nTesting slice assignment:")
 bv1 = BitVector(size=25)
 print("bv1= " + str(bv1))  # 0000000000000000000000000
-bv2 = BitVector(bitstring="1010001")
+bv2 = BitVector.from_bitstring("1010001")
 print("bv2= " + str(bv2))  # 1010001
 bv1[6:9] = bv2[0:3]
 print("bv1= " + str(bv1))  # 0000001010000000000000000
@@ -469,7 +469,7 @@ print("bv3= " + str(bv3))  # 0101001010000000000001010
 print("\nTesting slice assignment with negative limits in RHS slice:")
 bv1 = BitVector(size=25)
 print("bv1= " + str(bv1))  # 0000000000000000000000000
-bv2 = BitVector(bitstring="1010111")
+bv2 = BitVector.from_bitstring("1010111")
 print("bv2= " + str(bv2))  # 1010001
 bv1[2:5] = bv2[-7:-4]
 print("bv1= " + str(bv1))  # 0010100000000000000000000
@@ -481,7 +481,7 @@ print("bv1= " + str(bv1))  # 0011101010000000000000000
 print("\nTesting slice assignment with negative limits in the LHS slice:")
 bv1 = BitVector(size=25)
 print("bv1= " + str(bv1))  # 0000000000000000000000000
-bv2 = BitVector(bitstring="1111001")
+bv2 = BitVector.from_bitstring("1111001")
 print("bv2= " + str(bv2))  # 1111001
 bv1[-5:-2] = bv2[0:3]
 print("bv1= " + str(bv1))  # 0000000000000000000011100
@@ -505,22 +505,22 @@ print(bv1[3:9].reset(0))  # 000000
 print(bv1[:].reset(0))  # 0000000000000000000000000
 
 print("\nTesting count_bit():")
-bv = BitVector(intVal=45, size=16)
+bv = BitVector.from_int(45, size=16)
 y = bv.count_bits()
 print(y)  # 4
-bv = BitVector(bitstring="100111")
+bv = BitVector.from_bitstring("100111")
 print(bv.count_bits())  # 4
-bv = BitVector(bitstring="00111000")
+bv = BitVector.from_bitstring("00111000")
 print(bv.count_bits())  # 3
-bv = BitVector(bitstring="001")
+bv = BitVector.from_bitstring("001")
 print(bv.count_bits())  # 1
-bv = BitVector(bitstring="00000000000000")
+bv = BitVector.from_bitstring("00000000000000")
 print(bv.count_bits())  # 0
 
 print("\nTest set_value idea:")
-bv = BitVector(intVal=7, size=16)
+bv = BitVector.from_int(7, size=16)
 print(bv)  # 0000000000000111
-bv.set_value(intVal=45)
+bv.set_value(bitlist=[1, 0, 1, 1, 0, 1])
 print(bv)  # 101101
 
 print("\nTesting count_bits_sparse():")
@@ -533,54 +533,54 @@ bv[785] = 1
 print("The number of bits set: " + str(bv.count_bits_sparse()))  # 5
 
 print("\nTesting Jaccard similarity and distance and Hamming distance:")
-bv1 = BitVector(bitstring="11111111")
-bv2 = BitVector(bitstring="00101011")
+bv1 = BitVector.from_bitstring("11111111")
+bv2 = BitVector.from_bitstring("00101011")
 print("Jaccard similarity: " + str(bv1.jaccard_similarity(bv2)))  # 0.5
 print("Jaccard distance: " + str(bv1.jaccard_distance(bv2)))  # 0.5
 print("Hamming distance: " + str(bv1.hamming_distance(bv2)))  # 4
 
 print("\nTesting next_set_bit():")
-bv = BitVector(bitstring="00000000000001")
+bv = BitVector.from_bitstring("00000000000001")
 print(bv.next_set_bit(5))  # 13
-bv = BitVector(bitstring="000000000000001")
+bv = BitVector.from_bitstring("000000000000001")
 print(bv.next_set_bit(5))  # 14
-bv = BitVector(bitstring="0000000000000001")
+bv = BitVector.from_bitstring("0000000000000001")
 print(bv.next_set_bit(5))  # 15
-bv = BitVector(bitstring="00000000000000001")
+bv = BitVector.from_bitstring("00000000000000001")
 print(bv.next_set_bit(5))  # 16
-bv = BitVector(bitstring="00000000000000000")
+bv = BitVector.from_bitstring("00000000000000000")
 print(bv.next_set_bit(5))  # -1
 
 print("\nTesting rank_of_bit_set_at_index():")
-bv = BitVector(bitstring="01010101011100")
+bv = BitVector.from_bitstring("01010101011100")
 print(bv.rank_of_bit_set_at_index(10))  # 6
 
 print("\nTesting is_power_of_2():")
-bv = BitVector(bitstring="10000000001110")
+bv = BitVector.from_bitstring("10000000001110")
 print("int value: " + str(int(bv)))  # 826
 print(bv.is_power_of_2())  # False
 print("\nTesting is_power_of_2_sparse():")
 print(bv.is_power_of_2_sparse())  # False
 
 print("\nTesting reverse():")
-bv = BitVector(bitstring="0001100000000000001")
+bv = BitVector.from_bitstring("0001100000000000001")
 print("original bv: " + str(bv))  # 0001100000000000001
 print("reversed bv: " + str(bv.reverse()))  # 1000000000000011000
 
 print("\nTesting Greatest Common Divisor (gcd):")
-bv1 = BitVector(bitstring="01100110")
+bv1 = BitVector.from_bitstring("01100110")
 print("first arg bv: " + str(bv1) + " of int value: " + str(int(bv1)))  # 102
-bv2 = BitVector(bitstring="011010")
+bv2 = BitVector.from_bitstring("011010")
 print("second arg bv: " + str(bv2) + " of int value: " + str(int(bv2)))  # 26
 bv = bv1.gcd(bv2)
 print("gcd bitvec is: " + str(bv) + " of int value: " + str(int(bv)))  # 2
 
 print("\nTesting multiplicative_inverse:")
-bv_modulus = BitVector(intVal=32)
+bv_modulus = BitVector.from_int(32)
 print(
     "modulus is bitvec: " + str(bv_modulus) + " of int value: " + str(int(bv_modulus))
 )
-bv = BitVector(intVal=17)
+bv = BitVector.from_int(17)
 print("bv: " + str(bv) + " of int value: " + str(int(bv)))
 mi_result = bv.multiplicative_inverse(bv_modulus)
 if mi_result is not None:
@@ -591,18 +591,18 @@ else:
 
 print("\nTest multiplication in GF(2):")
 # a = BitVector( bitstring='0110001' )
-a = BitVector(bitstring="00000010")
+a = BitVector.from_bitstring("00000010")
 
 # b = BitVector( bitstring='0110' )
-b = BitVector(bitstring="000001111")
+b = BitVector.from_bitstring("000001111")
 
 c = a.gf_multiply(b)
 print("Product of a=" + str(a) + " b=" + str(b) + " is " + str(c))
 
 print("\nTest division in GF(2^n):")
-mod = BitVector(bitstring="100011011")  # AES modulus
+mod = BitVector.from_bitstring("100011011")  # AES modulus
 n = 8
-a = BitVector(bitstring="11100010110001")
+a = BitVector.from_bitstring("11100010110001")
 quotient, remainder = a.gf_divide_by_modulus(mod, n)
 print(
     "Dividing a="
@@ -616,10 +616,10 @@ print(
 )
 
 print("\nTest modular multiplication in GF(2^n):")
-modulus = BitVector(bitstring="100011011")  # AES modulus
+modulus = BitVector.from_bitstring("100011011")  # AES modulus
 n = 8
-a = BitVector(bitstring="0110001")
-b = BitVector(bitstring="0110")
+a = BitVector.from_bitstring("0110001")
+b = BitVector.from_bitstring("0110")
 c = a.gf_multiply_modular(b, modulus, n)
 print("Modular product of a=" + str(a) + " b=" + str(b) + " in GF(2^8) is " + str(c))
 
@@ -628,9 +628,9 @@ print(
     + "modulus polynomial = x^3 + x + 1:"
 )
 print("Find multiplicative inverse of a single bit array")
-modulus = BitVector(bitstring="100011011")  # AES modulus
+modulus = BitVector.from_bitstring("100011011")  # AES modulus
 n = 8
-a = BitVector(bitstring="00110011")
+a = BitVector.from_bitstring("00110011")
 mi = a.gf_MI(modulus, n)
 print("Multiplicative inverse of " + str(a) + " in GF(2^8) is " + str(mi))
 
@@ -640,9 +640,9 @@ print(
     + "\nand the third the product of a binary word with its"
     + "\nmultiplicative inverse:\n"
 )
-mod = BitVector(bitstring="1011")
+mod = BitVector.from_bitstring("1011")
 n = 3
-bitarrays = [BitVector(intVal=x, size=n) for x in range(1, 2**3)]
+bitarrays = [BitVector.from_int(x, size=n) for x in range(1, 2**3)]
 mi_list = [x.gf_MI(mod, n) for x in bitarrays]
 mi_str_list = [str(x.gf_MI(mod, n)) for x in bitarrays]
 print("bit arrays in GF(2^3): " + str([str(x) for x in bitarrays]))
@@ -663,7 +663,7 @@ print("bit_array * multi_inv: " + str(products))
 #    print("\n(This may take a few seconds)\n")
 #    mod = BitVector( bitstring = '100011011' )
 #    n = 8
-#    bitarrays = [BitVector(intVal=x, size=n) for x in range(1,2**8)]
+#    bitarrays = [BitVector.from_int(x, size=n) for x in range(1,2**8)]
 #    mi_list = [x.gf_MI(mod,n) for x in bitarrays]
 #    mi_str_list = [str(x.gf_MI(mod,n)) for x in bitarrays]
 #    print("\nMultiplicative Inverses:\n\n" + str(mi_str_list))
@@ -760,12 +760,12 @@ primes = [
     7841,
 ]
 for p in primes:
-    bv = BitVector(intVal=p)
+    bv = BitVector.from_int(p)
     check = bv.test_for_primality()
     print("The primality test for " + str(p) + ": " + str(check))
 
 print("\nGenerate 32-bit wide candidate for primality testing:")
-bv = BitVector(intVal=0)
+bv = BitVector.from_int(0)
 bv = bv.gen_random_bits(32)
 print(bv)
 check = bv.test_for_primality()
@@ -773,6 +773,6 @@ print("The primality test for " + str(int(bv)) + ": " + str(check))
 
 print("\nTest generating min-canonical form of a BitVector instance:")
 for i in range(255, 10000, 1555):
-    bv = BitVector(intVal=i, size=14)
+    bv = BitVector.from_int(i, size=14)
     print(f"\nbv:            {bv}")
     print(f"min canonical: {bv.min_canonical()}")

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -16,32 +16,32 @@ import BitVector
 
 @pytest.fixture
 def sample_bv1():
-    return BitVector.BitVector(bitstring="01" * 500)
+    return BitVector.BitVector.from_bitstring("01" * 500)
 
 
 @pytest.fixture
 def sample_bv2():
-    return BitVector.BitVector(bitstring="001" * 333 + "0")
+    return BitVector.BitVector.from_bitstring("001" * 333 + "0")
 
 
 @pytest.fixture
 def sample_bv_small():
-    return BitVector.BitVector(bitstring="01010111" * 8)
+    return BitVector.BitVector.from_bitstring("01010111" * 8)
 
 
 @pytest.fixture
 def gf_a():
-    return BitVector.BitVector(bitstring="0110001")
+    return BitVector.BitVector.from_bitstring("0110001")
 
 
 @pytest.fixture
 def gf_b():
-    return BitVector.BitVector(bitstring="0110")
+    return BitVector.BitVector.from_bitstring("0110")
 
 
 @pytest.fixture
 def gf_mod():
-    return BitVector.BitVector(bitstring="100011011")  # AES modulus
+    return BitVector.BitVector.from_bitstring("100011011")  # AES modulus
 
 
 # --- Constructor Benchmarks ---
@@ -52,17 +52,17 @@ def test_bench_init_zeros(benchmark):
 
 
 def test_bench_init_int(benchmark):
-    benchmark(BitVector.BitVector, intVal=0x123456789ABCDEF0, size=64)
+    benchmark(BitVector.BitVector.from_int, 0x123456789ABCDEF0, size=64)
 
 
 def test_bench_init_bitstring(benchmark):
     bitstr = "1010" * 250
-    benchmark(BitVector.BitVector, bitstring=bitstr)
+    benchmark(BitVector.BitVector.from_bitstring, bitstr)
 
 
 def test_bench_init_rawbytes(benchmark):
     data = b"\xaa\x55" * 50
-    benchmark(BitVector.BitVector, rawbytes=data)
+    benchmark(BitVector.BitVector.from_bytes, data)
 
 
 # --- Bitwise Operation Benchmarks ---
@@ -427,7 +427,7 @@ def test_bench_set_value(benchmark, sample_bv1):
         return (copy.deepcopy(sample_bv1),), {}
 
     def target(bv):
-        bv.set_value(intVal=0x1234567890ABCDEF, size=64)
+        bv.set_value(bitlist=[1, 0, 1, 0, 1, 1, 0, 0] * 8)
 
     benchmark.pedantic(target, setup=setup, rounds=100)
 
@@ -445,7 +445,7 @@ def test_bench_gf_multiply(benchmark, gf_a, gf_b):
 
 
 def test_bench_gf_divide_by_modulus(benchmark, gf_mod):
-    a = BitVector.BitVector(bitstring="11100010110001")
+    a = BitVector.BitVector.from_bitstring("11100010110001")
     benchmark(a.gf_divide_by_modulus, gf_mod, 8)
 
 
@@ -454,24 +454,24 @@ def test_bench_gf_multiply_modular(benchmark, gf_a, gf_b, gf_mod):
 
 
 def test_bench_gf_mi(benchmark, gf_mod):
-    a = BitVector.BitVector(bitstring="00110011")
+    a = BitVector.BitVector.from_bitstring("00110011")
     benchmark(a.gf_MI, gf_mod, 8)
 
 
 def test_bench_multiplicative_inverse(benchmark):
-    bv_mod = BitVector.BitVector(intVal=32)
-    bv_has_mi = BitVector.BitVector(intVal=17)
+    bv_mod = BitVector.BitVector.from_int(32)
+    bv_has_mi = BitVector.BitVector.from_int(17)
     benchmark(bv_has_mi.multiplicative_inverse, bv_mod)
 
 
 def test_bench_gcd(benchmark):
-    bv1 = BitVector.BitVector(bitstring="01100110")
-    bv2 = BitVector.BitVector(bitstring="011010")
+    bv1 = BitVector.BitVector.from_bitstring("01100110")
+    bv2 = BitVector.BitVector.from_bitstring("011010")
     benchmark(bv1.gcd, bv2)
 
 
 def test_bench_test_for_primality(benchmark):
-    prob_19 = BitVector.BitVector(intVal=19, size=16)
+    prob_19 = BitVector.BitVector.from_int(19, size=16)
     benchmark(prob_19.test_for_primality)
 
 

--- a/tests/test_boolean_logic.py
+++ b/tests/test_boolean_logic.py
@@ -19,7 +19,7 @@ BINARY_OP_MAP: dict[BinaryOp, Callable[[Any, Any], Any]] = {
 @pytest.fixture
 def bv1() -> BitVector.BitVector:
     """Returns an 8-bit vector constructed from a bitstring ('00110011')."""
-    return BitVector.BitVector(bitstring="00110011")
+    return BitVector.BitVector.from_bitstring("00110011")
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def bv2() -> BitVector.BitVector:
 @pytest.fixture
 def bv3() -> BitVector.BitVector:
     """Returns a 23-bit vector constructed from a bitstring."""
-    return BitVector.BitVector(bitstring="00000000111111110000000")
+    return BitVector.BitVector.from_bitstring("00000000111111110000000")
 
 
 @pytest.fixture
@@ -77,7 +77,7 @@ def test_binary_logic_operators(
     right: BitVector.BitVector = request.getfixturevalue(right_name)
     op_func = BINARY_OP_MAP[op]
     result = op_func(left, right)
-    assert result == BitVector.BitVector(bitstring=expected)
+    assert result == BitVector.BitVector.from_bitstring(expected)
 
 
 @pytest.mark.parametrize(
@@ -100,4 +100,4 @@ def test_unary_not_operator(
     """
     bv: BitVector.BitVector = request.getfixturevalue(bv_name)
     result = ~bv
-    assert result == BitVector.BitVector(bitstring=expected)
+    assert result == BitVector.BitVector.from_bitstring(expected)

--- a/tests/test_circular_shifts.py
+++ b/tests/test_circular_shifts.py
@@ -31,7 +31,7 @@ def test_circular_shifts(
         op: The shift operator to apply ('>>' or '<<').
         expected: The expected bitstring representation after rotation.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     if op == ">>":
         result = bv >> shift
     elif op == "<<":
@@ -39,7 +39,7 @@ def test_circular_shifts(
     else:
         raise ValueError(f"Unsupported operator: {op}")
 
-    expected_bv = BitVector.BitVector(bitstring=expected)
+    expected_bv = BitVector.BitVector.from_bitstring(expected)
     assert result == expected_bv
     assert str(bv) == bitstring
     assert result is not bv
@@ -62,7 +62,7 @@ def test_inplace_circular_shifts(
     bitstring: str, shift: int, op: Literal[">>=", "<<="], expected: str
 ) -> None:
     """Tests in-place circular shift operators >>= and <<= on BitVector instances."""
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     ref = bv
     if op == ">>=":
         bv >>= shift
@@ -71,7 +71,7 @@ def test_inplace_circular_shifts(
     else:
         raise ValueError(f"Unsupported operator: {op}")
 
-    expected_bv = BitVector.BitVector(bitstring=expected)
+    expected_bv = BitVector.BitVector.from_bitstring(expected)
     assert bv == expected_bv
     assert bv is ref
 

--- a/tests/test_comparison_ops.py
+++ b/tests/test_comparison_ops.py
@@ -22,7 +22,7 @@ OP_MAP: dict[ComparisonOp, Callable[[Any, Any], bool]] = {
 @pytest.fixture
 def bv1() -> BitVector.BitVector:
     """Returns an 8-bit vector constructed from a bitstring (value 51)."""
-    return BitVector.BitVector(bitstring="00110011")
+    return BitVector.BitVector.from_bitstring("00110011")
 
 
 @pytest.fixture
@@ -34,7 +34,7 @@ def bv2() -> BitVector.BitVector:
 @pytest.fixture
 def bv3() -> BitVector.BitVector:
     """Returns a 13-bit vector constructed from an integer (value 5678)."""
-    return BitVector.BitVector(intVal=5678)
+    return BitVector.BitVector.from_int(5678)
 
 
 @pytest.mark.parametrize(
@@ -108,14 +108,14 @@ def test_comparison_with_numeric_types(
     bv_val: int, other: int | float, op: ComparisonOp, expected: bool
 ) -> None:
     """Tests comparisons between BitVector and int/float."""
-    bv = BitVector.BitVector(intVal=bv_val)
+    bv = BitVector.BitVector.from_int(bv_val)
     compare_func = OP_MAP[op]
     assert compare_func(bv, other) is expected
 
 
 def test_eq_ne_with_unsupported_types() -> None:
     """Tests that == and != work with any type and don't raise TypeError."""
-    bv = BitVector.BitVector(intVal=51)
+    bv = BitVector.BitVector.from_int(51)
     assert (bv == "hello") is False
     assert (bv != "hello") is True
     assert (bv == [51]) is False
@@ -129,7 +129,7 @@ def test_order_comparisons_with_unsupported_types_raise_type_error(
     op: ComparisonOp,
 ) -> None:
     """Tests that <, <=, >, and >= raise TypeError for unsupported types."""
-    bv = BitVector.BitVector(intVal=51)
+    bv = BitVector.BitVector.from_int(51)
     compare_func = OP_MAP[op]
     with pytest.raises(TypeError):
         compare_func(bv, "hello")
@@ -142,33 +142,33 @@ def test_order_comparisons_with_unsupported_types_raise_type_error(
 def test_eq_large_vectors() -> None:
     """Tests equality on multi-word large bitvectors."""
     # 1000-bit equal vectors
-    vec1 = BitVector.BitVector(bitstring="1010" * 250)
-    vec2 = BitVector.BitVector(bitstring="1010" * 250)
+    vec1 = BitVector.BitVector.from_bitstring("1010" * 250)
+    vec2 = BitVector.BitVector.from_bitstring("1010" * 250)
     assert vec1 == vec2
 
     # Differ in first word
-    vec3 = BitVector.BitVector(bitstring="0010" + "1010" * 249)
+    vec3 = BitVector.BitVector.from_bitstring("0010" + "1010" * 249)
     assert vec1 != vec3
 
     # Differ in middle word (around bit 500)
     bits_mid = list("1010" * 250)
     bits_mid[500] = "0"
-    vec4 = BitVector.BitVector(bitstring="".join(bits_mid))
+    vec4 = BitVector.BitVector.from_bitstring("".join(bits_mid))
     assert vec1 != vec4
 
     # Differ in last word (bit 999 is 0, flip to 1)
     bits_last = list("1010" * 250)
     bits_last[999] = "1"
-    vec5 = BitVector.BitVector(bitstring="".join(bits_last))
+    vec5 = BitVector.BitVector.from_bitstring("".join(bits_last))
     assert vec1 != vec5
 
 
 def test_eq_with_differing_unused_bits() -> None:
     """Tests equality when unused bits in the last integer word differ."""
-    vec1 = BitVector.BitVector(bitstring="10101")
+    vec1 = BitVector.BitVector.from_bitstring("10101")
     vec1_inv = ~vec1  # Bits: "01010", but unused high bits in last word are 1s
-    vec2 = BitVector.BitVector(
-        bitstring="01010"
+    vec2 = BitVector.BitVector.from_bitstring(
+        "01010"
     )  # Bits: "01010", unused high bits are 0s
     assert vec1_inv == vec2
     assert vec2 == vec1_inv

--- a/tests/test_dunder.py
+++ b/tests/test_dunder.py
@@ -33,8 +33,8 @@ def test_bitwise_dunder_operators(
         op: The bitwise operator string ('^', '&', or '|').
         expected: Expected output bitstring after applying the operator.
     """
-    bv_left = BitVector.BitVector(bitstring=left_str)
-    bv_right = BitVector.BitVector(bitstring=right_str)
+    bv_left = BitVector.BitVector.from_bitstring(left_str)
+    bv_right = BitVector.BitVector.from_bitstring(right_str)
     if op == "^":
         res = bv_left ^ bv_right
     elif op == "&":
@@ -64,12 +64,12 @@ def test_add(left_str: str, right_str: str, expected: str) -> None:
         expected: Expected output bitstring after concatenation.
     """
     left = (
-        BitVector.BitVector(bitstring=left_str)
+        BitVector.BitVector.from_bitstring(left_str)
         if left_str
         else BitVector.BitVector(size=0)
     )
     right = (
-        BitVector.BitVector(bitstring=right_str)
+        BitVector.BitVector.from_bitstring(right_str)
         if right_str
         else BitVector.BitVector(size=0)
     )
@@ -78,17 +78,17 @@ def test_add(left_str: str, right_str: str, expected: str) -> None:
 
 def test_add_vector_type_fallback() -> None:
     """Tests __add__ fallback branches when self.vector is a list or tuple."""
-    bv2 = BitVector.BitVector(bitstring="010")
+    bv2 = BitVector.BitVector.from_bitstring("010")
 
-    bv_tuple = BitVector.BitVector(bitstring="1001")
+    bv_tuple = BitVector.BitVector.from_bitstring("1001")
     bv_tuple.vector = tuple(bv_tuple.vector)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     assert str(bv_tuple + bv2) == "1001010"
 
 
 def test_iadd() -> None:
     """Tests in-place concatenation dunder (__iadd__) and type validation."""
-    bv1 = BitVector.BitVector(bitstring="101")
-    bv2 = BitVector.BitVector(bitstring="010")
+    bv1 = BitVector.BitVector.from_bitstring("101")
+    bv2 = BitVector.BitVector.from_bitstring("010")
     bv1 += bv2
     assert str(bv1) == "101010"
 
@@ -114,8 +114,8 @@ def test_iadd() -> None:
 )
 def test_iadd_alignment_cases(s1: str, s2: str) -> None:
     """Tests __iadd__ across various word-alignment boundaries and sizes."""
-    bv1 = BitVector.BitVector(bitstring=s1) if s1 else BitVector.BitVector(size=0)
-    bv2 = BitVector.BitVector(bitstring=s2) if s2 else BitVector.BitVector(size=0)
+    bv1 = BitVector.BitVector.from_bitstring(s1) if s1 else BitVector.BitVector(size=0)
+    bv2 = BitVector.BitVector.from_bitstring(s2) if s2 else BitVector.BitVector(size=0)
     bv1 += bv2
     assert str(bv1) == s1 + s2
     assert len(bv1) == len(s1) + len(s2)
@@ -134,7 +134,7 @@ def test_iadd_alignment_cases(s1: str, s2: str) -> None:
 )
 def test_iadd_self_concatenation(s: str) -> None:
     """Tests in-place self-concatenation (bv += bv)."""
-    bv = BitVector.BitVector(bitstring=s)
+    bv = BitVector.BitVector.from_bitstring(s)
     bv += bv
     assert str(bv) == s + s
     assert len(bv) == len(s) * 2
@@ -155,7 +155,7 @@ def test_invert(bitstring: str, expected: str) -> None:
         expected: Expected output bitstring after inversion.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -164,7 +164,7 @@ def test_invert(bitstring: str, expected: str) -> None:
 
 def test_deepcopy() -> None:
     """Tests deep copying via copy.deepcopy, memoization, and fallbacks."""
-    bv = BitVector.BitVector(bitstring="10110")
+    bv = BitVector.BitVector.from_bitstring("10110")
     bv_copy = copy.deepcopy(bv)
     assert str(bv_copy) == "10110"
     assert bv_copy is not bv
@@ -176,7 +176,7 @@ def test_deepcopy() -> None:
     # pylint: disable-next=unnecessary-dunder-call
     assert str(bv.__deepcopy__()) == "10110"
 
-    bv_tuple = BitVector.BitVector(bitstring="1001")
+    bv_tuple = BitVector.BitVector.from_bitstring("1001")
     bv_tuple.vector = tuple(bv_tuple.vector)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     bv_tuple_copy = copy.deepcopy(bv_tuple)
     assert str(bv_tuple_copy) == "1001"
@@ -198,7 +198,7 @@ def test_lshift(shift: int, expected: str) -> None:
         shift: Number of bit positions to rotate left.
         expected: Expected output bitstring.
     """
-    bv = BitVector.BitVector(bitstring="1000")
+    bv = BitVector.BitVector.from_bitstring("1000")
     res = bv << shift
     assert str(res) == expected
     assert str(bv) == "1000"
@@ -207,7 +207,7 @@ def test_lshift(shift: int, expected: str) -> None:
 
 def test_ilshift() -> None:
     """Tests in-place circular left shift dunder (__ilshift__ / <<=)."""
-    bv = BitVector.BitVector(bitstring="1000")
+    bv = BitVector.BitVector.from_bitstring("1000")
     ref = bv
     bv <<= 1
     assert str(bv) == "0001"
@@ -253,7 +253,7 @@ def test_rshift(shift: int, expected: str) -> None:
         shift: Number of bit positions to rotate right.
         expected: Expected output bitstring.
     """
-    bv = BitVector.BitVector(bitstring="1000")
+    bv = BitVector.BitVector.from_bitstring("1000")
     res = bv >> shift
     assert str(res) == expected
     assert str(bv) == "1000"
@@ -262,7 +262,7 @@ def test_rshift(shift: int, expected: str) -> None:
 
 def test_irshift() -> None:
     """Tests in-place circular right shift dunder (__irshift__ / >>=)."""
-    bv = BitVector.BitVector(bitstring="1000")
+    bv = BitVector.BitVector.from_bitstring("1000")
     ref = bv
     bv >>= 1
     assert str(bv) == "0100"
@@ -352,16 +352,16 @@ def test_setitem_slice_assignment(
         valid_str: A bitstring of valid length for assignment.
         expected: Expected vector bitstring after assignment.
     """
-    bv = BitVector.BitVector(bitstring=initial)
+    bv = BitVector.BitVector.from_bitstring(initial)
     with pytest.raises(ValueError, match=err_match):
         bv[sl] = BitVector.BitVector(size=err_size)
-    bv[sl] = BitVector.BitVector(bitstring=valid_str)
+    bv[sl] = BitVector.BitVector.from_bitstring(valid_str)
     assert str(bv) == expected
 
 
 def test_setitem_index_assignment() -> None:
     """Tests __setitem__ with positive and negative integer indices."""
-    bv = BitVector.BitVector(bitstring="000")
+    bv = BitVector.BitVector.from_bitstring("000")
     bv[1] = 1
     bv[-1] = 1
     assert str(bv) == "011"
@@ -371,7 +371,7 @@ def test_setitem_index_assignment() -> None:
 
 def test_setitem_slice_type_error() -> None:
     """Verifies slice assignment with a non-BitVector raises TypeError."""
-    bv = BitVector.BitVector(bitstring="000")
+    bv = BitVector.BitVector.from_bitstring("000")
     with pytest.raises(
         TypeError,
         match="For slice assignment, the right hand side must be a BitVector",
@@ -381,8 +381,8 @@ def test_setitem_slice_type_error() -> None:
 
 def test_setitem_full_slice() -> None:
     """Tests __setitem__ when replacing the entire slice ([:])."""
-    bv = BitVector.BitVector(bitstring="1010")
-    bv[:] = BitVector.BitVector(bitstring="0101")
+    bv = BitVector.BitVector.from_bitstring("1010")
+    bv[:] = BitVector.BitVector.from_bitstring("0101")
     assert str(bv) == "1010"
 
 
@@ -401,7 +401,7 @@ def test_str(bitstring: str, expected: str) -> None:
         expected: Expected string representation.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -410,7 +410,7 @@ def test_str(bitstring: str, expected: str) -> None:
 
 def test_format() -> None:
     """Tests __format__ string and integer interpolation."""
-    bv = BitVector.BitVector(intVal=15, size=8)
+    bv = BitVector.BitVector.from_int(15, size=8)
 
     # Test formatting with no specifier (defaults to str)
     assert f"{bv}" == "00001111"
@@ -432,7 +432,7 @@ def test_format() -> None:
     assert f"{bv:#X}" == "0XF"
 
     # Test formatting with grouping
-    bv2 = BitVector.BitVector(intVal=255, size=8)
+    bv2 = BitVector.BitVector.from_int(255, size=8)
     assert f"{bv2:,}" == "255"
     assert f"{bv2:_}" == "255"
 
@@ -440,7 +440,7 @@ def test_format() -> None:
     assert f"{bv:f}" == "15.000000"
 
     # Test non-even multiples of 4 or 8
-    bv3 = BitVector.BitVector(intVal=15, size=7)
+    bv3 = BitVector.BitVector.from_int(15, size=7)
     assert f"{bv3}" == "0001111"
     assert f"{bv3:x}" == "f"
 
@@ -469,7 +469,7 @@ def test_int(bitstring: str, expected: int) -> None:
         expected: Expected integer conversion output.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -505,7 +505,7 @@ def test_reversed(bitstring: str, expected_bits: list[int]) -> None:
         expected_bits: Expected list of integer bits yielded in reverse order.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -532,7 +532,7 @@ def test_reversed_block_boundaries(size: int) -> None:
 
     bits = ["1" if (i % 7 == 0 or i == size - 1) else "0" for i in range(size)]
     bitstr = "".join(bits)
-    bv = BitVector.BitVector(bitstring=bitstr)
+    bv = BitVector.BitVector.from_bitstring(bitstr)
     expected = [int(c) for c in reversed(bitstr)]
 
     assert list(reversed(bv)) == expected
@@ -558,12 +558,12 @@ def test_eq(left_str: str, right_str: str, expected: bool) -> None:
         expected: Expected boolean equality result.
     """
     left = (
-        BitVector.BitVector(bitstring=left_str)
+        BitVector.BitVector.from_bitstring(left_str)
         if left_str
         else BitVector.BitVector(size=0)
     )
     right = (
-        BitVector.BitVector(bitstring=right_str)
+        BitVector.BitVector.from_bitstring(right_str)
         if right_str
         else BitVector.BitVector(size=0)
     )
@@ -585,8 +585,8 @@ def test_ne(left_str: str, right_str: str, expected: bool) -> None:
         right_str: Bitstring for the right operand.
         expected: Expected boolean inequality result.
     """
-    left = BitVector.BitVector(bitstring=left_str)
-    right = BitVector.BitVector(bitstring=right_str)
+    left = BitVector.BitVector.from_bitstring(left_str)
+    right = BitVector.BitVector.from_bitstring(right_str)
     assert (left != right) is expected
 
 
@@ -618,8 +618,8 @@ def test_relational_operators(
         op: Relational operator string ('<', '<=', '>', '>=').
         expected: Expected boolean comparison result.
     """
-    bv1 = BitVector.BitVector(intVal=val1, size=8)
-    bv2 = BitVector.BitVector(intVal=val2, size=8)
+    bv1 = BitVector.BitVector.from_int(val1, size=8)
+    bv2 = BitVector.BitVector.from_int(val2, size=8)
     if op == "<":
         res = bv1 < bv2
     elif op == "<=":
@@ -647,8 +647,8 @@ def test_contains(pattern: str, expected_in: bool) -> None:
         pattern: The bitstring pattern to search for.
         expected_in: True if pattern is found in the vector, otherwise False.
     """
-    bv = BitVector.BitVector(bitstring="110100")
-    sub_bv = BitVector.BitVector(bitstring=pattern)
+    bv = BitVector.BitVector.from_bitstring("110100")
+    sub_bv = BitVector.BitVector.from_bitstring(pattern)
     assert (sub_bv in bv) is expected_in
 
 
@@ -670,10 +670,10 @@ def test_contains_invalid_args_raises_error(
         err_match: The expected error message substring.
     """
     target = (
-        BitVector.BitVector(bitstring=target_str)
+        BitVector.BitVector.from_bitstring(target_str)
         if target_str
         else BitVector.BitVector(size=0)
     )
-    pattern = BitVector.BitVector(bitstring=pattern_str)
+    pattern = BitVector.BitVector.from_bitstring(pattern_str)
     with pytest.raises(ValueError, match=err_match):
         _ = pattern in target

--- a/tests/test_get_set.py
+++ b/tests/test_get_set.py
@@ -53,7 +53,7 @@ def test_setitem_raises_error(index: int, val: int, err_match: str) -> None:
         val: The bit value to assign (should be 0 or 1).
         err_match: The expected error message substring.
     """
-    bv = BitVector.BitVector(bitstring="00000")
+    bv = BitVector.BitVector.from_bitstring("00000")
     with pytest.raises(ValueError, match=err_match):
         bv[index] = val
 
@@ -78,7 +78,7 @@ def test_setitem_valid(
         val: The bit value (0 or 1) to assign.
         expected: The expected vector bitstring after modification.
     """
-    bv = BitVector.BitVector(bitstring=initial)
+    bv = BitVector.BitVector.from_bitstring(initial)
     bv[cast(Any, index)] = val
     assert str(bv) == expected
 
@@ -90,7 +90,7 @@ def test_getitem_int_raises_error(index: int) -> None:
     Args:
         index: The out-of-bounds index to query.
     """
-    bv = BitVector.BitVector(bitstring="10110")
+    bv = BitVector.BitVector.from_bitstring("10110")
     with pytest.raises(ValueError, match="index range error"):
         bv[index]  # pylint: disable=pointless-statement
 
@@ -111,7 +111,7 @@ def test_getitem_int(index: int, expected: int) -> None:
         index: The bit index to query.
         expected: The expected integer bit value (0 or 1).
     """
-    bv = BitVector.BitVector(bitstring="10110")
+    bv = BitVector.BitVector.from_bitstring("10110")
     assert bv[index] == expected
 
 
@@ -139,7 +139,7 @@ def test_getitem_slice(initial: str, sl: slice, expected: str) -> None:
         expected: Expected bitstring representation of the extracted slice.
     """
     bv = (
-        BitVector.BitVector(bitstring=initial)
+        BitVector.BitVector.from_bitstring(initial)
         if initial
         else BitVector.BitVector(size=0)
     )
@@ -164,14 +164,14 @@ def test_getitem_slice_raises_error(sl: slice) -> None:
     Args:
         sl: The invalid slice object to test on a 5-bit vector.
     """
-    bv = BitVector.BitVector(bitstring="10110")
+    bv = BitVector.BitVector.from_bitstring("10110")
     with pytest.raises(ValueError, match="illegal slice index values"):
         _ = bv[sl]
 
 
 def test_bitvector_iterator() -> None:
     """Tests sequential iteration over bits in a BitVector."""
-    bv = BitVector.BitVector(bitstring="101")
+    bv = BitVector.BitVector.from_bitstring("101")
     it = iter(bv)
     assert isinstance(it, Iterator)
     assert iter(it) is it

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -36,37 +36,11 @@ def test_invalid_keyword_error() -> None:
 @pytest.mark.parametrize(
     ("kwargs", "err_match"),
     [
-        ({"intVal": 5, "bitstring": "101"}, "When intVal is specified"),
-        (
-            {"intVal": 0, "size": 0},
-            "The value specified for size must be at least",
-        ),
-        (
-            {"intVal": 0, "size": -1},
-            "The value specified for size must be at least",
-        ),
-        (
-            {"intVal": 5, "size": 0},
-            "The value specified for size must be at least",
-        ),
-        (
-            {"intVal": 255, "size": 2},
-            "The value specified for size must be at least",
-        ),
         (
             {"size": 10, "bitlist": [1, 0]},
-            r"When size is specified \(without an intVal\)",
+            r"When size is specified",
         ),
         ({"size": -5}, r"wrong arg\(s\) for constructor"),
-        ({"bitstring": "1010", "rawbytes": b"xy"}, "When a bitstring is specified"),
-        (
-            {"bitlist": [1, 0], "rawbytes": b"xy"},
-            "When bits are specified, you cannot give values",
-        ),
-        (
-            {"rawbytes": b"xy", "size": -5},
-            "When bits are specified through rawbytes",
-        ),
         ({}, r"wrong arg\(s\) for constructor"),
     ],
 )
@@ -84,21 +58,33 @@ def test_constructor_conflicting_args_raises_error(
 
 
 @pytest.mark.parametrize(
+    ("kwargs", "err_match"),
+    [
+        ({"intVal": 5}, "unexpected keyword argument"),
+        ({"bitstring": "1010"}, "unexpected keyword argument"),
+        ({"rawbytes": b"xy"}, "unexpected keyword argument"),
+    ],
+)
+def test_constructor_legacy_kwargs_raise_type_error(
+    kwargs: dict[str, Any], err_match: str
+) -> None:
+    """Verifies that removed legacy constructor arguments raise TypeError.
+
+    Args:
+        kwargs: Legacy keyword arguments.
+        err_match: The expected regex error message pattern.
+    """
+    with pytest.raises(TypeError, match=err_match):
+        BitVector.BitVector(**kwargs)
+
+
+@pytest.mark.parametrize(
     ("kwargs", "expected_str", "expected_size"),
     [
-        ({"intVal": 0}, "0", 1),
-        ({"intVal": 0, "size": 5}, "00000", 5),
-        ({"intVal": 5}, "101", 3),
-        ({"intVal": 32}, "100000", 6),
-        ({"intVal": 5, "size": 10}, "0000000101", 10),
         ({"size": 10}, "0000000000", 10),
         ({"size": 0}, "", 0),
-        ({"bitstring": "00110011"}, "00110011", 8),
-        ({"bitstring": ""}, "", 0),
         ({"bitlist": [1, 1, 0, 1]}, "1101", 4),
         ({"bitlist": []}, "", 0),
-        ({"rawbytes": b"\x00\xff"}, "0000000011111111", 16),
-        ({"rawbytes": b""}, "", 0),
     ],
 )
 def test_constructor_valid_kwargs(
@@ -138,15 +124,15 @@ def test_from_hex() -> None:
 
 def test_intVal_zero_hex_helper() -> None:
     """Tests intVal zero evaluation using the ZeroHex helper class."""
-    bv = BitVector.BitVector(
-        intVal=ZeroHex(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    bv = BitVector.BitVector.from_int(
+        val=ZeroHex(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         size=0,
     )
     assert bv._size == 0
     assert str(bv) == ""
 
-    bv2 = BitVector.BitVector(
-        intVal=ZeroHex(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+    bv2 = BitVector.BitVector.from_int(
+        val=ZeroHex(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         size=5,
     )
     assert bv2._size == 5

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -9,7 +9,7 @@ import BitVector
 
 def test_divide_into_two_raises_error() -> None:
     """Verifies dividing a vector with an odd number of bits raises ValueError."""
-    bv_odd = BitVector.BitVector(bitstring="101")
+    bv_odd = BitVector.BitVector.from_bitstring("101")
     with pytest.raises(ValueError, match="must have even num bits"):
         bv_odd.divide_into_two()
 
@@ -32,7 +32,7 @@ def test_divide_into_two(
         expected_right: Expected bitstring of the right half vector.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -57,7 +57,7 @@ def test_permute_raises_error(
         perm_list: List of target bit indices for permutation.
         err_match: Expected error message pattern.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match=err_match):
         bv.permute(perm_list)
 
@@ -77,7 +77,7 @@ def test_permute(bitstring: str, perm_list: list[int], expected: str) -> None:
         perm_list: List of target bit indices for permutation.
         expected: Expected output vector bitstring.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     permuted = bv.permute(perm_list)
     assert str(permuted) == expected
 
@@ -99,14 +99,14 @@ def test_unpermute_raises_error(
         perm_list: List of permutation indices.
         err_match: Expected error message pattern.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match=err_match):
         bv.unpermute(perm_list)
 
 
 def test_unpermute() -> None:
     """Tests round-trip permutation and unpermutation."""
-    bv_orig = BitVector.BitVector(bitstring="11001010")
+    bv_orig = BitVector.BitVector.from_bitstring("11001010")
     p_list = [7, 6, 5, 4, 3, 2, 1, 0]
     permuted = bv_orig.permute(p_list)
     unpermuted = permuted.unpermute(p_list)
@@ -140,7 +140,7 @@ def test_rotations_and_one_bit_shifts(
         bitstring: Initial vector bitstring representation.
         expected: Expected output vector bitstring after mutation.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     method = getattr(bv, method_name)
     method()
     assert str(bv) == expected
@@ -163,7 +163,7 @@ def test_shift_left_right(direction: str, shift_amount: int, expected: str) -> N
         shift_amount: Number of bit positions to shift.
         expected: Expected output vector bitstring.
     """
-    bv = BitVector.BitVector(bitstring="101101")
+    bv = BitVector.BitVector.from_bitstring("101101")
     if direction == "left":
         res = bv.shift_left(shift_amount)
     else:
@@ -196,7 +196,7 @@ def test_shift_left_comprehensive(
         shift_amount: Number of positions to shift left.
         expected_bitstring: Expected bitstring representation after shifting.
     """
-    bv = BitVector.BitVector(bitstring=initial_bitstring)
+    bv = BitVector.BitVector.from_bitstring(initial_bitstring)
     res = bv.shift_left(shift_amount)
     assert res is bv
     assert str(bv) == expected_bitstring
@@ -226,7 +226,7 @@ def test_shift_right_comprehensive(
         shift_amount: Number of positions to shift right.
         expected_bitstring: Expected bitstring representation after shifting.
     """
-    bv = BitVector.BitVector(bitstring=initial_bitstring)
+    bv = BitVector.BitVector.from_bitstring(initial_bitstring)
     res = bv.shift_right(shift_amount)
     assert res is bv
     assert str(bv) == expected_bitstring
@@ -234,7 +234,7 @@ def test_shift_right_comprehensive(
 
 def test_shift_right_extended_vector() -> None:
     """Verifies shift_right clears trailing excess words when vector storage is over-allocated."""
-    bv = BitVector.BitVector(bitstring="1" * 65)
+    bv = BitVector.BitVector.from_bitstring("1" * 65)
     bv.vector.append(999)
     res = bv.shift_right(1)
     assert res is bv
@@ -273,7 +273,7 @@ def test_padding(
         expected_str: Expected output vector bitstring.
     """
     bv = (
-        BitVector.BitVector(bitstring=input_str)
+        BitVector.BitVector.from_bitstring(input_str)
         if input_str
         else BitVector.BitVector(size=0)
     )
@@ -289,7 +289,7 @@ def test_padding(
 
 def test_reset_raises_error() -> None:
     """Verifies calling reset with an invalid bit value raises ValueError."""
-    bv = BitVector.BitVector(bitstring="101")
+    bv = BitVector.BitVector.from_bitstring("101")
     with pytest.raises(ValueError, match="Incorrect reset argument"):
         bv.reset(2)
 
@@ -308,7 +308,7 @@ def test_reset(val: int, expected: str) -> None:
         val: The bit value (0 or 1) to reset all bits to.
         expected: Expected output vector bitstring.
     """
-    bv = BitVector.BitVector(bitstring="101")
+    bv = BitVector.BitVector.from_bitstring("101")
     res = bv.reset(val)
     assert str(bv) == expected
     assert res is bv
@@ -342,7 +342,7 @@ def test_count_bits(bitstring: str, expected_count: int) -> None:
         expected_count: Expected number of bits set to 1.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -366,7 +366,7 @@ def test_count_bits_sparse(bitstring: str, expected_count: int) -> None:
         expected_count: Expected number of bits set to 1.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -375,24 +375,24 @@ def test_count_bits_sparse(bitstring: str, expected_count: int) -> None:
 
 def test_set_value() -> None:
     """Tests mutating an existing BitVector via set_value."""
-    bv = BitVector.BitVector(intVal=7, size=16)
-    bv.set_value(intVal=45)
+    bv = BitVector.BitVector.from_int(7, size=16)
+    bv.set_value(bitlist=[1, 0, 1, 1, 0, 1])
     assert str(bv) == "101101"
 
-    bv.set_value(bitstring="1100")
-    assert str(bv) == "1100"
+    bv.set_value(size=10)
+    assert str(bv) == "0000000000"
 
 
 def test_set_value_positional_args_error() -> None:
     """Verifies that passing positional arguments to set_value raises TypeError."""
-    bv = BitVector.BitVector(intVal=7, size=16)
+    bv = BitVector.BitVector.from_int(7, size=16)
     with pytest.raises(TypeError, match="takes 1 positional argument"):
         bv.set_value(123)  # type: ignore[misc,arg-type]  # ty: ignore[too-many-positional-arguments]
 
 
 def test_set_value_invalid_keyword_error() -> None:
     """Verifies passing unexpected keyword arguments to set_value raises TypeError."""
-    bv = BitVector.BitVector(intVal=7, size=16)
+    bv = BitVector.BitVector.from_int(7, size=16)
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         # pylint: disable-next=unexpected-keyword-arg
         bv.set_value(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
@@ -418,8 +418,8 @@ def test_distance_metrics_raise_error(
         bv2_str: Bitstring for the second vector.
         err_match: Expected error message substring.
     """
-    bv1 = BitVector.BitVector(bitstring=bv1_str)
-    bv2 = BitVector.BitVector(bitstring=bv2_str)
+    bv1 = BitVector.BitVector.from_bitstring(bv1_str)
+    bv2 = BitVector.BitVector.from_bitstring(bv2_str)
     method = getattr(bv1, method_name)
     with pytest.raises(ValueError, match=err_match):
         method(bv2)
@@ -444,8 +444,8 @@ def test_distance_metrics(
         bv2_str: Bitstring for the second vector.
         expected: Expected distance or similarity numerical result.
     """
-    bv1 = BitVector.BitVector(bitstring=bv1_str)
-    bv2 = BitVector.BitVector(bitstring=bv2_str)
+    bv1 = BitVector.BitVector.from_bitstring(bv1_str)
+    bv2 = BitVector.BitVector.from_bitstring(bv2_str)
     method = getattr(bv1, method_name)
     res = method(bv2)
     if isinstance(expected, float):
@@ -456,7 +456,7 @@ def test_distance_metrics(
 
 def test_next_set_bit_raises_error() -> None:
     """Verifies calling next_set_bit with a negative index raises ValueError."""
-    bv = BitVector.BitVector(bitstring="00000000000001")
+    bv = BitVector.BitVector.from_bitstring("00000000000001")
     with pytest.raises(ValueError, match="from_index must be nonnegative"):
         bv.next_set_bit(-1)
 
@@ -477,20 +477,20 @@ def test_next_set_bit(bitstring: str, start_idx: int, expected_idx: int) -> None
         start_idx: The starting index for scanning.
         expected_idx: Expected index of the next set bit (-1 if none found).
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     assert bv.next_set_bit(start_idx) == expected_idx
 
 
 def test_rank_of_bit_set_at_index_raises_error() -> None:
     """Verifies rank query on an unset bit raises ValueError."""
-    bv = BitVector.BitVector(bitstring="01010101011100")
+    bv = BitVector.BitVector.from_bitstring("01010101011100")
     with pytest.raises(ValueError, match="the arg bit not set"):
         bv.rank_of_bit_set_at_index(0)
 
 
 def test_rank_of_bit_set_at_index() -> None:
     """Tests calculating the rank (number of preceding 1 bits) of a set bit."""
-    bv = BitVector.BitVector(bitstring="01010101011100")
+    bv = BitVector.BitVector.from_bitstring("01010101011100")
     assert bv.rank_of_bit_set_at_index(10) == 6
 
 
@@ -512,7 +512,7 @@ def test_is_power_of_2(bitstring: str, sparse: bool, expected: bool) -> None:
         sparse: Whether to use is_power_of_2_sparse.
         expected: Expected boolean result.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     res = bv.is_power_of_2_sparse() if sparse else bv.is_power_of_2()
     assert res is expected
 
@@ -532,7 +532,7 @@ def test_reverse(bitstring: str, expected: str) -> None:
         expected: Expected bitstring representation after reversal.
     """
     bv = (
-        BitVector.BitVector(bitstring=bitstring)
+        BitVector.BitVector.from_bitstring(bitstring)
         if bitstring
         else BitVector.BitVector(size=0)
     )
@@ -541,44 +541,44 @@ def test_reverse(bitstring: str, expected: str) -> None:
 
 def test_gcd() -> None:
     """Tests greatest common divisor calculation between two vectors."""
-    bv1 = BitVector.BitVector(bitstring="01100110")  # 102
-    bv2 = BitVector.BitVector(bitstring="011010")  # 26
+    bv1 = BitVector.BitVector.from_bitstring("01100110")  # 102
+    bv2 = BitVector.BitVector.from_bitstring("011010")  # 26
     assert int(bv1.gcd(bv2)) == 2
     assert int(bv2.gcd(bv1)) == 2
 
 
 def test_multiplicative_inverse() -> None:
     """Tests modular multiplicative inverse existence and calculation."""
-    bv_mod = BitVector.BitVector(intVal=32)
-    bv_has_mi = BitVector.BitVector(intVal=17)
+    bv_mod = BitVector.BitVector.from_int(32)
+    bv_has_mi = BitVector.BitVector.from_int(17)
     res = bv_has_mi.multiplicative_inverse(bv_mod)
     assert res is not None
     assert int(res) == 17
 
-    bv_no_mi = BitVector.BitVector(intVal=2)
+    bv_no_mi = BitVector.BitVector.from_int(2)
     res_none = bv_no_mi.multiplicative_inverse(bv_mod)
     assert res_none is None
 
 
 def test_gf_multiply() -> None:
     """Tests polynomial multiplication over GF(2)."""
-    a = BitVector.BitVector(bitstring="0110001")
-    b = BitVector.BitVector(bitstring="0110")
+    a = BitVector.BitVector.from_bitstring("0110001")
+    b = BitVector.BitVector.from_bitstring("0110")
     c = a.gf_multiply(b)
     assert str(c) == "00010100110"
 
-    b_zero = BitVector.BitVector(bitstring="0000")
+    b_zero = BitVector.BitVector.from_bitstring("0000")
     c_zero = a.gf_multiply(b_zero)
     assert int(c_zero) == 0
 
 
 def test_gf_divide_by_modulus() -> None:
     """Tests polynomial division by modulus over GF(2^n) and error checking."""
-    mod = BitVector.BitVector(bitstring="100011011")  # AES modulus
+    mod = BitVector.BitVector.from_bitstring("100011011")  # AES modulus
     n = 8
-    a = BitVector.BitVector(bitstring="11100010110001")
+    a = BitVector.BitVector.from_bitstring("11100010110001")
 
-    mod_long = BitVector.BitVector(bitstring="1" * 15)
+    mod_long = BitVector.BitVector.from_bitstring("1" * 15)
     with pytest.raises(ValueError, match="Modulus bit pattern too long"):
         a.gf_divide_by_modulus(mod_long, n)
 
@@ -590,32 +590,32 @@ def test_gf_divide_by_modulus() -> None:
     _, r_eq = a_equal.gf_divide_by_modulus(mod, n)
     assert int(r_eq) == 0
 
-    _, r_zero = BitVector.BitVector(bitstring="0").gf_divide_by_modulus(
-        BitVector.BitVector(bitstring="1"), 1
+    _, r_zero = BitVector.BitVector.from_bitstring("0").gf_divide_by_modulus(
+        BitVector.BitVector.from_bitstring("1"), 1
     )
     assert int(r_zero) == 0
 
 
 def test_gf_multiply_modular() -> None:
     """Tests modular polynomial multiplication over GF(2^8)."""
-    mod = BitVector.BitVector(bitstring="100011011")  # AES modulus
+    mod = BitVector.BitVector.from_bitstring("100011011")  # AES modulus
     n = 8
-    a = BitVector.BitVector(bitstring="0110001")
-    b = BitVector.BitVector(bitstring="0110")
+    a = BitVector.BitVector.from_bitstring("0110001")
+    b = BitVector.BitVector.from_bitstring("0110")
     c = a.gf_multiply_modular(b, mod, n)
     assert str(c) == "10100110"
 
 
 def test_gf_mi() -> None:
     """Tests multiplicative inverse over GF(2^n) and non-existent fallback."""
-    mod = BitVector.BitVector(bitstring="100011011")
+    mod = BitVector.BitVector.from_bitstring("100011011")
     n = 8
-    a = BitVector.BitVector(bitstring="00110011")
+    a = BitVector.BitVector.from_bitstring("00110011")
     mi = a.gf_MI(mod, n)
     assert str(mi) == "01101100"
 
-    mod_no_mi = BitVector.BitVector(bitstring="1010")
-    a_no_mi = BitVector.BitVector(bitstring="0010")
+    mod_no_mi = BitVector.BitVector.from_bitstring("1010")
+    a_no_mi = BitVector.BitVector.from_bitstring("0010")
     res_no_mi = a_no_mi.gf_MI(mod_no_mi, 3)
     assert isinstance(res_no_mi, str)
     assert res_no_mi == "NO MI. However, the GCD of 0010 and 1010 is 010"
@@ -642,7 +642,7 @@ def test_runs(
     """
     if bitstring is not None:
         bv = (
-            BitVector.BitVector(bitstring=bitstring)
+            BitVector.BitVector.from_bitstring(bitstring)
             if bitstring
             else BitVector.BitVector(size=0)
         )
@@ -655,17 +655,17 @@ def test_runs(
 
 def test_test_for_primality() -> None:
     """Tests Miller-Rabin and small-probe primality verification."""
-    assert BitVector.BitVector(intVal=1, size=8).test_for_primality() == 0
-    assert BitVector.BitVector(intVal=2, size=8).test_for_primality() == 1
-    assert BitVector.BitVector(intVal=17, size=8).test_for_primality() == 1
-    assert BitVector.BitVector(intVal=25, size=8).test_for_primality() == 0
+    assert BitVector.BitVector.from_int(1, size=8).test_for_primality() == 0
+    assert BitVector.BitVector.from_int(2, size=8).test_for_primality() == 1
+    assert BitVector.BitVector.from_int(17, size=8).test_for_primality() == 1
+    assert BitVector.BitVector.from_int(25, size=8).test_for_primality() == 0
 
-    prob_19 = BitVector.BitVector(intVal=19, size=16).test_for_primality()
+    prob_19 = BitVector.BitVector.from_int(19, size=16).test_for_primality()
     assert prob_19 > 0.99
-    prob_41 = BitVector.BitVector(intVal=41, size=16).test_for_primality()
+    prob_41 = BitVector.BitVector.from_int(41, size=16).test_for_primality()
     assert prob_41 > 0.99
 
-    assert BitVector.BitVector(intVal=361, size=16).test_for_primality() == 0
+    assert BitVector.BitVector.from_int(361, size=16).test_for_primality() == 0
 
 
 def test_gen_random_bits(mocker) -> None:
@@ -691,5 +691,5 @@ def test_gen_random_bits(mocker) -> None:
 
 def test_min_canonical() -> None:
     """Tests finding the lexicographically smallest circular rotation."""
-    bv = BitVector.BitVector(bitstring="1101")
+    bv = BitVector.BitVector.from_bitstring("1101")
     assert str(bv.min_canonical()) == "0111"

--- a/tests/test_permutations.py
+++ b/tests/test_permutations.py
@@ -54,7 +54,7 @@ def test_permutations(
     else:
         raise ValueError(f"Unsupported operator: {op}")
 
-    assert result == BitVector.BitVector(bitstring=expected)
+    assert result == BitVector.BitVector.from_bitstring(expected)
 
 
 @pytest.mark.parametrize("op", ["permute", "unpermute"])

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -23,8 +23,8 @@ def test_addition_after_inversion(bits1: str, bits2: str) -> None:
         bits2: Bitstring representation for the second operand.
     """
     expected = "".join("1" if b == "0" else "0" for b in bits1) + bits2
-    bv1 = BitVector.BitVector(bitstring=bits1)
-    bv2 = BitVector.BitVector(bitstring=bits2)
+    bv1 = BitVector.BitVector.from_bitstring(bits1)
+    bv2 = BitVector.BitVector.from_bitstring(bits2)
     result_bv = (~bv1) + bv2
     assert str(result_bv) == expected, f"Failed on inputs: {bits1}, {bits2}"
 
@@ -41,13 +41,13 @@ def test_addition_consistency(bits1: str, bits2: str) -> None:
         bits2: Bitstring representation for the second operand.
     """
     expected = bits1 + bits2
-    bv1 = BitVector.BitVector(bitstring=bits1)
-    bv2 = BitVector.BitVector(bitstring=bits2)
+    bv1 = BitVector.BitVector.from_bitstring(bits1)
+    bv2 = BitVector.BitVector.from_bitstring(bits2)
 
     added_bv = bv1 + bv2
     assert str(added_bv) == expected
 
-    bv1_copy = BitVector.BitVector(bitstring=bits1)
+    bv1_copy = BitVector.BitVector.from_bitstring(bits1)
     bv1_copy += bv2
     assert str(bv1_copy) == expected
 
@@ -59,7 +59,7 @@ def test_invert_involution(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv = BitVector.BitVector(bitstring=bits)
+    bv = BitVector.BitVector.from_bitstring(bits)
     double_inv = ~(~bv)
     assert str(double_inv) == bits
     assert double_inv == bv
@@ -77,8 +77,8 @@ def test_bitwise_commutativity(bits1: str, bits2: str) -> None:
         bits2: Bitstring representation for the second operand.
     """
     min_len = min(len(bits1), len(bits2))
-    bv1 = BitVector.BitVector(bitstring=bits1[:min_len])
-    bv2 = BitVector.BitVector(bitstring=bits2[:min_len])
+    bv1 = BitVector.BitVector.from_bitstring(bits1[:min_len])
+    bv2 = BitVector.BitVector.from_bitstring(bits2[:min_len])
 
     assert str(bv1 & bv2) == str(bv2 & bv1)
     assert str(bv1 | bv2) == str(bv2 | bv1)
@@ -96,7 +96,7 @@ def test_circular_rotation_reversibility(bits: str, shift: int) -> None:
         bits: Bitstring representation of the test vector.
         shift: Number of positions to rotate.
     """
-    bv = BitVector.BitVector(bitstring=bits)
+    bv = BitVector.BitVector.from_bitstring(bits)
     rotated = bv << shift
     rotated = rotated >> shift
     assert str(rotated) == bits
@@ -114,7 +114,7 @@ def test_reverse_involution(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv = BitVector.BitVector(bitstring=bits)
+    bv = BitVector.BitVector.from_bitstring(bits)
     bv.reverse()
     bv.reverse()
     assert str(bv) == bits
@@ -127,12 +127,12 @@ def test_int_roundtrip(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv = BitVector.BitVector(bitstring=bits)
+    bv = BitVector.BitVector.from_bitstring(bits)
     val = int(bv)
     expected_val = int(bits, 2)
     assert val == expected_val
 
-    reconstructed = BitVector.BitVector(intVal=val, size=len(bits))
+    reconstructed = BitVector.BitVector.from_int(val, size=len(bits))
     assert str(reconstructed) == bits
 
 
@@ -159,7 +159,11 @@ def test_slicing_consistency(bits: str, start: int | None, stop: int | None) -> 
     if start is not None and stop is not None and start > stop:
         start, stop = stop, start
 
-    bv = BitVector.BitVector(bitstring=bits) if bits else BitVector.BitVector(size=0)
+    bv = (
+        BitVector.BitVector.from_bitstring(bits)
+        if bits
+        else BitVector.BitVector(size=0)
+    )
     sl = slice(start, stop)
     try:
         sliced_bv = bv[sl]
@@ -180,14 +184,14 @@ def test_circular_rotation_equivalency(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv_left1 = BitVector.BitVector(bitstring=bits)
-    bv_left2 = BitVector.BitVector(bitstring=bits)
+    bv_left1 = BitVector.BitVector.from_bitstring(bits)
+    bv_left2 = BitVector.BitVector.from_bitstring(bits)
     bv_left1.circular_rot_left()
     bv_left2.circular_rotate_left_by_one()
     assert str(bv_left1) == str(bv_left2)
 
-    bv_right1 = BitVector.BitVector(bitstring=bits)
-    bv_right2 = BitVector.BitVector(bitstring=bits)
+    bv_right1 = BitVector.BitVector.from_bitstring(bits)
+    bv_right2 = BitVector.BitVector.from_bitstring(bits)
     bv_right1.circular_rot_right()
     bv_right2.circular_rotate_right_by_one()
     assert str(bv_right1) == str(bv_right2)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -9,7 +9,7 @@ from BitVector import BitVector, BitVectorProtocol
 
 
 def test_protocol() -> None:
-    bv = BitVector(intVal=42, size=8)
+    bv = BitVector.from_int(42, size=8)
     bv_proto = cast(BitVectorProtocol, bv)
     assert int(bv_proto) == 42
     assert len(bv_proto) == 8

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -9,7 +9,7 @@ import BitVector
 
 def test_write_bits_to_stream_object() -> None:
     """Tests writing ASCII bit characters to a text stream object."""
-    bv = BitVector.BitVector(bitstring="101100101")
+    bv = BitVector.BitVector.from_bitstring("101100101")
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == "101100101"
@@ -17,7 +17,7 @@ def test_write_bits_to_stream_object() -> None:
 
 def test_write_to_file_raises_error() -> None:
     """Verifies writing a vector not a multiple of 8 bits raises ValueError."""
-    bv = BitVector.BitVector(bitstring="10101")
+    bv = BitVector.BitVector.from_bitstring("10101")
     with pytest.raises(
         ValueError, match="Only a bit vector whose length is a multiple of 8"
     ):
@@ -26,7 +26,7 @@ def test_write_to_file_raises_error() -> None:
 
 def test_write_to_file() -> None:
     """Tests writing packed bytes to a binary stream and appending."""
-    bv = BitVector.BitVector(bitstring="0100000101000010")  # 'AB'
+    bv = BitVector.BitVector.from_bitstring("0100000101000010")  # 'AB'
     out_stream = io.BytesIO()
     bv.write_to_file(out_stream)
     assert out_stream.getvalue() == b"AB"

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,27 +1,25 @@
 """Tests for string output representations (ASCII, hex, and str) of BitVector."""
 
-from typing import Any
-
 import pytest
 
 import BitVector
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "expected"),
+    ("bitstring", "expected"),
     [
-        ({"bitstring": "01000001"}, "A"),
-        ({"size": 0}, ""),
+        ("01000001", "A"),
+        ("", ""),
     ],
 )
-def test_get_bitvector_in_ascii(kwargs: dict[str, Any], expected: str) -> None:
+def test_get_bitvector_in_ascii(bitstring: str, expected: str) -> None:
     """Tests ASCII string conversion across valid BitVector instances.
 
     Args:
-        kwargs: Keyword arguments used to initialize the BitVector instance.
+        bitstring: Input binary string.
         expected: The expected ASCII representation string.
     """
-    bv = BitVector.BitVector(**kwargs)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     assert bv.get_bitvector_in_ascii() == expected
 
 
@@ -38,27 +36,27 @@ def test_get_bitvector_in_ascii_invalid_length_raises_error(bitstring: str) -> N
     Args:
         bitstring: A bitstring whose length is not a multiple of 8.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match="must be an integral multiple of 8 bits"):
         bv.get_bitvector_in_ascii()
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "expected"),
+    ("bitstring", "expected"),
     [
-        ({"bitstring": "1111"}, "f"),
-        ({"bitstring": "10100000"}, "a0"),
-        ({"size": 0}, ""),
+        ("1111", "f"),
+        ("10100000", "a0"),
+        ("", ""),
     ],
 )
-def test_get_bitvector_in_hex(kwargs: dict[str, Any], expected: str) -> None:
+def test_get_bitvector_in_hex(bitstring: str, expected: str) -> None:
     """Tests hexadecimal string conversion across valid BitVector instances.
 
     Args:
-        kwargs: Keyword arguments used to initialize the BitVector instance.
+        bitstring: Input binary string.
         expected: The expected hexadecimal representation string.
     """
-    bv = BitVector.BitVector(**kwargs)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     assert bv.get_bitvector_in_hex() == expected
 
 
@@ -75,26 +73,26 @@ def test_get_bitvector_in_hex_invalid_length_raises_error(bitstring: str) -> Non
     Args:
         bitstring: A bitstring whose length is not a multiple of 4.
     """
-    bv = BitVector.BitVector(bitstring=bitstring)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match="must be an integral multiple of 4 bits"):
         bv.get_bitvector_in_hex()
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "expected"),
+    ("bitstring", "expected"),
     [
-        ({"bitstring": "01010111"}, "01010111"),
-        ({"size": 0}, ""),
+        ("01010111", "01010111"),
+        ("", ""),
     ],
 )
-def test_str_representation(kwargs: dict[str, Any], expected: str) -> None:
+def test_str_representation(bitstring: str, expected: str) -> None:
     """Tests the string (__str__) representation of BitVector instances.
 
     Args:
-        kwargs: Keyword arguments used to initialize the BitVector instance.
+        bitstring: Input binary string.
         expected: The expected binary string representation.
     """
-    bv = BitVector.BitVector(**kwargs)
+    bv = BitVector.BitVector.from_bitstring(bitstring)
     assert str(bv) == expected
 
 


### PR DESCRIPTION
  1. `__init__` & `set_value` API Simplification:
      * Updated BitVector.__init__ signature in BitVector.py to accept only size and bitlist keyword arguments (`BitVector(*, size: int | None = None, bitlist: Sequence[int] | None = None)`).
      * Removed legacy intVal, bitstring, and rawbytes constructor parameters. Passing any of these parameters to `__init__` or set_value now raises TypeError.
      * Updated BitVector.set_value signature to accept only size and bitlist.
  2. Methodology & Codebase Updates:
      * Replaced all legacy intVal=, bitstring=, and rawbytes= constructor calls throughout BitVector/BitVector.py, test suites (test_boolean_logic.py, test_circular_shifts.py, test_comparison_ops.py, test_dunder.py, test_get_set.py, test_operations.py, test_permutations.py, test_properties.py, test_stream.py, test_string.py, test_benchmarks.py), and demo.py with their explicit classmethod counterparts (from_int, from_bitstring, from_bytes).
      * Updated documentation in AGENTS.md to accurately reflect the constructor API.