### PR TITLE
perf(iter): iterate over internal vector at word level

### DIFF
--- a/BitVector/BitVector.py
+++ b/BitVector/BitVector.py
@@ -1111,7 +1111,11 @@ class BitVector:
         Yields:
             The integer bit value (0 or 1) at each position from left to right.
         """
-        yield from (self[i] for i in range(self._size))
+        size = self._size
+        for word_idx, word in enumerate(self.vector):
+            bits_in_word = min(64, size - word_idx * 64)
+            for bit_idx in range(bits_in_word):
+                yield (word >> bit_idx) & 1
 
     def __reversed__(self) -> Iterator[int]:
         """Yields individual bits sequentially from right to left.


### PR DESCRIPTION
  * Eliminated Call Overhead: Replaced `yield from (self[i] for i in range(self._size))` with direct 64-bit word iteration, avoiding  method call overhead and repeated index-to-word offset math (`i // 64` and `i & 63`) on every bit.
  * Branch & Version Control: Committed to dedicated feature branch BitVector.py (perf(iter): iterate over internal vector at word level).
  ──────
  ### Performance Comparison

  Running pytest-benchmark on test_bench_iter (iterating over a 10,000-bit BitVector):

   Iteration Method          | Baseline (self[i] per bit)            | Word-Level Iteration (enumerate(sel… | Speedup Factor | Latency…
  ---------------------------|---------------------------------------|--------------------------------------|----------------|----------
   `__iter__ (list(iter(bv)))` | 269.30 µs (Mean) / 265.52 µs (Median) | 66.63 µs (Mean) / 65.33 µs (Median)  | 4.04x faster   | -75.3%

  Forward iteration performance is now on par with reverse iteration (`__reversed__`, ~65.55 µs).
