### PR TITLE
refactor(tests): standardize imports to from BitVector import BitVector

### DIFF
--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -12,75 +12,75 @@ import pathlib
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 @pytest.fixture
 def sample_bv1():
-    return BitVector.BitVector.from_bitstring("01" * 500)
+    return BitVector.from_bitstring("01" * 500)
 
 
 @pytest.fixture
 def sample_bv2():
-    return BitVector.BitVector.from_bitstring("001" * 333 + "0")
+    return BitVector.from_bitstring("001" * 333 + "0")
 
 
 @pytest.fixture
 def sample_bv_small():
-    return BitVector.BitVector.from_bitstring("01010111" * 8)
+    return BitVector.from_bitstring("01010111" * 8)
 
 
 @pytest.fixture
 def gf_a():
-    return BitVector.BitVector.from_bitstring("0110001")
+    return BitVector.from_bitstring("0110001")
 
 
 @pytest.fixture
 def gf_b():
-    return BitVector.BitVector.from_bitstring("0110")
+    return BitVector.from_bitstring("0110")
 
 
 @pytest.fixture
 def gf_mod():
-    return BitVector.BitVector.from_bitstring("100011011")  # AES modulus
+    return BitVector.from_bitstring("100011011")  # AES modulus
 
 
 # --- Constructor Benchmarks ---
 
 
 def test_bench_init_zeros(benchmark):
-    benchmark(BitVector.BitVector, size=1000)
+    benchmark(BitVector, size=1000)
 
 
 def test_bench_init_int(benchmark):
-    benchmark(BitVector.BitVector.from_int, 0x123456789ABCDEF0, size=64)
+    benchmark(BitVector.from_int, 0x123456789ABCDEF0, size=64)
 
 
 def test_bench_init_int_large(benchmark):
     val = (1 << 1000) - 123456789
-    benchmark(BitVector.BitVector.from_int, val, size=1000)
+    benchmark(BitVector.from_int, val, size=1000)
 
 
 def test_bench_init_bitstring(benchmark):
     bitstr = "1010" * 250
-    benchmark(BitVector.BitVector.from_bitstring, bitstr)
+    benchmark(BitVector.from_bitstring, bitstr)
 
 
 def test_bench_init_rawbytes(benchmark):
     data = b"\xaa\x55" * 50
-    benchmark(BitVector.BitVector.from_bytes, data)
+    benchmark(BitVector.from_bytes, data)
 
 
 def test_bench_init_bitlist(benchmark):
     bitlist = [1, 0, 1, 0] * 250
-    benchmark(BitVector.BitVector, bitlist=bitlist)
+    benchmark(BitVector, bitlist=bitlist)
 
 
 def test_bench_from_stream(benchmark):
     data = b"\xaa\x55" * 50
 
-    def read_stream() -> BitVector.BitVector:
-        return BitVector.BitVector.from_stream(io.BytesIO(data))
+    def read_stream() -> BitVector:
+        return BitVector.from_stream(io.BytesIO(data))
 
     benchmark(read_stream)
 
@@ -97,7 +97,7 @@ def test_bench_from_file_path(
 ):
     file_path = tmp_path / f"bench_test_{size_bytes}.bin"
     file_path.write_bytes(b"\xaa" * size_bytes)
-    benchmark(BitVector.BitVector.from_file_path, file_path)
+    benchmark(BitVector.from_file_path, file_path)
 
 
 # --- Bitwise Operation Benchmarks ---
@@ -229,7 +229,7 @@ def test_bench_slice_aligned(benchmark, sample_bv1):
 
 
 def test_bench_slice_large(benchmark):
-    bv = BitVector.BitVector.from_bitstring("10" * 5000)  # 10,000 bits
+    bv = BitVector.from_bitstring("10" * 5000)  # 10,000 bits
     benchmark(operator.getitem, bv, slice(1000, 9000))
 
 
@@ -495,7 +495,7 @@ def test_bench_gf_multiply(benchmark, gf_a, gf_b):
 
 
 def test_bench_gf_divide_by_modulus(benchmark, gf_mod):
-    a = BitVector.BitVector.from_bitstring("11100010110001")
+    a = BitVector.from_bitstring("11100010110001")
     benchmark(a.gf_divide_by_modulus, gf_mod, 8)
 
 
@@ -504,27 +504,27 @@ def test_bench_gf_multiply_modular(benchmark, gf_a, gf_b, gf_mod):
 
 
 def test_bench_gf_mi(benchmark, gf_mod):
-    a = BitVector.BitVector.from_bitstring("00110011")
+    a = BitVector.from_bitstring("00110011")
     benchmark(a.gf_MI, gf_mod, 8)
 
 
 def test_bench_multiplicative_inverse(benchmark):
-    bv_mod = BitVector.BitVector.from_int(32)
-    bv_has_mi = BitVector.BitVector.from_int(17)
+    bv_mod = BitVector.from_int(32)
+    bv_has_mi = BitVector.from_int(17)
     benchmark(bv_has_mi.multiplicative_inverse, bv_mod)
 
 
 def test_bench_gcd(benchmark):
-    bv1 = BitVector.BitVector.from_bitstring("01100110")
-    bv2 = BitVector.BitVector.from_bitstring("011010")
+    bv1 = BitVector.from_bitstring("01100110")
+    bv2 = BitVector.from_bitstring("011010")
     benchmark(bv1.gcd, bv2)
 
 
 def test_bench_test_for_primality(benchmark):
-    prob_19 = BitVector.BitVector.from_int(19, size=16)
+    prob_19 = BitVector.from_int(19, size=16)
     benchmark(prob_19.test_for_primality)
 
 
 def test_bench_gen_random_bits(benchmark):
-    bv = BitVector.BitVector(size=0)
+    bv = BitVector(size=0)
     benchmark(bv.gen_random_bits, 64)

--- a/tests/test_boolean_logic.py
+++ b/tests/test_boolean_logic.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Literal
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 BinaryOp = Literal["&", "|", "^"]
 
@@ -17,27 +17,27 @@ BINARY_OP_MAP: dict[BinaryOp, Callable[[Any, Any], Any]] = {
 
 
 @pytest.fixture
-def bv1() -> BitVector.BitVector:
+def bv1() -> BitVector:
     """Returns an 8-bit vector constructed from a bitstring ('00110011')."""
-    return BitVector.BitVector.from_bitstring("00110011")
+    return BitVector.from_bitstring("00110011")
 
 
 @pytest.fixture
-def bv2() -> BitVector.BitVector:
+def bv2() -> BitVector:
     """Returns an 8-bit vector constructed from a bitlist ('11110011')."""
-    return BitVector.BitVector(bitlist=[1, 1, 1, 1, 0, 0, 1, 1])
+    return BitVector(bitlist=[1, 1, 1, 1, 0, 0, 1, 1])
 
 
 @pytest.fixture
-def bv3() -> BitVector.BitVector:
+def bv3() -> BitVector:
     """Returns a 23-bit vector constructed from a bitstring."""
-    return BitVector.BitVector.from_bitstring("00000000111111110000000")
+    return BitVector.from_bitstring("00000000111111110000000")
 
 
 @pytest.fixture
-def bv_empty() -> BitVector.BitVector:
+def bv_empty() -> BitVector:
     """Returns an empty 0-bit vector."""
-    return BitVector.BitVector(size=0)
+    return BitVector(size=0)
 
 
 @pytest.mark.parametrize(
@@ -73,11 +73,11 @@ def test_binary_logic_operators(
         op: The binary logic operator string ('&', '|', '^').
         expected: The expected bitstring representation of the result.
     """
-    left: BitVector.BitVector = request.getfixturevalue(left_name)
-    right: BitVector.BitVector = request.getfixturevalue(right_name)
+    left: BitVector = request.getfixturevalue(left_name)
+    right: BitVector = request.getfixturevalue(right_name)
     op_func = BINARY_OP_MAP[op]
     result = op_func(left, right)
-    assert result == BitVector.BitVector.from_bitstring(expected)
+    assert result == BitVector.from_bitstring(expected)
 
 
 @pytest.mark.parametrize(
@@ -98,9 +98,9 @@ def test_unary_not_operator(
         bv_name: The fixture name of the target BitVector instance.
         expected: The expected bitstring representation after bitwise inversion.
     """
-    bv: BitVector.BitVector = request.getfixturevalue(bv_name)
+    bv: BitVector = request.getfixturevalue(bv_name)
     result = ~bv
-    assert result == BitVector.BitVector.from_bitstring(expected)
+    assert result == BitVector.from_bitstring(expected)
 
 
 @pytest.mark.parametrize(
@@ -139,8 +139,8 @@ def test_inplace_binary_logic_operators(
         op: The in-place binary logic operator string ('&=', '|=', '^=').
         expected: The expected bitstring representation of the result.
     """
-    left: BitVector.BitVector = request.getfixturevalue(left_name)[:]
-    right: BitVector.BitVector = request.getfixturevalue(right_name)
+    left: BitVector = request.getfixturevalue(left_name)[:]
+    right: BitVector = request.getfixturevalue(right_name)
     original_id = id(left)
 
     if op == "&=":
@@ -151,12 +151,12 @@ def test_inplace_binary_logic_operators(
         left ^= right
 
     assert id(left) == original_id
-    assert left == BitVector.BitVector.from_bitstring(expected)
+    assert left == BitVector.from_bitstring(expected)
 
 
 def test_inplace_binary_logic_type_errors() -> None:
     """Tests TypeError exceptions raised when passing non-BitVector types to &=, |=, ^=."""
-    bv = BitVector.BitVector.from_bitstring("1010")
+    bv = BitVector.from_bitstring("1010")
 
     with pytest.raises(TypeError):
         bv &= "1010"  # type: ignore[arg-type]  # ty: ignore[unsupported-operator]
@@ -170,7 +170,7 @@ def test_inplace_binary_logic_type_errors() -> None:
 
 def test_unused_bits_masked_after_invert() -> None:
     """Verifies that ~ (bitwise NOT) clears unused trailing bits in the last word."""
-    bv = BitVector.BitVector(bitlist=[1, 0, 1])  # size = 3
+    bv = BitVector(bitlist=[1, 0, 1])  # size = 3
     inv = ~bv
     assert inv._size == 3
     assert inv.vector[0] == 2  # bits 0..2 are 0, 1, 0; bits 3..63 must be 0
@@ -179,8 +179,8 @@ def test_unused_bits_masked_after_invert() -> None:
 
 def test_unused_bits_masked_unequal_length_logical_ops() -> None:
     """Verifies that logical ops between unequal length vectors clear residual bits in final word."""
-    bv_a = ~BitVector.BitVector(bitlist=[1, 0, 1])  # size 3, inverted
-    bv_b = BitVector.BitVector(bitlist=[1, 1, 0, 1, 0])  # size 5
+    bv_a = ~BitVector(bitlist=[1, 0, 1])  # size 3, inverted
+    bv_b = BitVector(bitlist=[1, 1, 0, 1, 0])  # size 5
 
     # Binary operations
     for op_func in (operator.and_, operator.or_, operator.xor):
@@ -196,8 +196,8 @@ def test_unused_bits_masked_unequal_length_logical_ops() -> None:
 
     # In-place operations
     for op_name in ("&=", "|=", "^="):
-        target = ~BitVector.BitVector(bitlist=[1, 0, 1])
-        operand = BitVector.BitVector(bitlist=[1, 1, 0, 1, 0])
+        target = ~BitVector(bitlist=[1, 0, 1])
+        operand = BitVector(bitlist=[1, 1, 0, 1, 0])
         if op_name == "&=":
             target &= operand
         elif op_name == "|=":

--- a/tests/test_circular_shifts.py
+++ b/tests/test_circular_shifts.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 @pytest.mark.parametrize(
@@ -31,7 +31,7 @@ def test_circular_shifts(
         op: The shift operator to apply ('>>' or '<<').
         expected: The expected bitstring representation after rotation.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     if op == ">>":
         result = bv >> shift
     elif op == "<<":
@@ -39,7 +39,7 @@ def test_circular_shifts(
     else:
         raise ValueError(f"Unsupported operator: {op}")
 
-    expected_bv = BitVector.BitVector.from_bitstring(expected)
+    expected_bv = BitVector.from_bitstring(expected)
     assert result == expected_bv
     assert str(bv) == bitstring
     assert result is not bv
@@ -62,7 +62,7 @@ def test_inplace_circular_shifts(
     bitstring: str, shift: int, op: Literal[">>=", "<<="], expected: str
 ) -> None:
     """Tests in-place circular shift operators >>= and <<= on BitVector instances."""
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     ref = bv
     if op == ">>=":
         bv >>= shift
@@ -71,7 +71,7 @@ def test_inplace_circular_shifts(
     else:
         raise ValueError(f"Unsupported operator: {op}")
 
-    expected_bv = BitVector.BitVector.from_bitstring(expected)
+    expected_bv = BitVector.from_bitstring(expected)
     assert bv == expected_bv
     assert bv is ref
 
@@ -83,7 +83,7 @@ def test_circular_shift_empty_vector_raises_error(op: str) -> None:
     Args:
         op: The shift operator to apply ('>>', '<<', '>>=', or '<<=').
     """
-    bv = BitVector.BitVector(size=0)
+    bv = BitVector(size=0)
     with pytest.raises(ValueError, match="Circular shift of an empty vector"):
         if op == ">>":
             _ = bv >> 1

--- a/tests/test_comparison_ops.py
+++ b/tests/test_comparison_ops.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Literal
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 ComparisonOp = Literal["==", "!=", "<", "<=", ">", ">="]
 
@@ -20,21 +20,21 @@ OP_MAP: dict[ComparisonOp, Callable[[Any, Any], bool]] = {
 
 
 @pytest.fixture
-def bv1() -> BitVector.BitVector:
+def bv1() -> BitVector:
     """Returns an 8-bit vector constructed from a bitstring (value 51)."""
-    return BitVector.BitVector.from_bitstring("00110011")
+    return BitVector.from_bitstring("00110011")
 
 
 @pytest.fixture
-def bv2() -> BitVector.BitVector:
+def bv2() -> BitVector:
     """Returns an 8-bit vector constructed from a bitlist (value 51)."""
-    return BitVector.BitVector(bitlist=[0, 0, 1, 1, 0, 0, 1, 1])
+    return BitVector(bitlist=[0, 0, 1, 1, 0, 0, 1, 1])
 
 
 @pytest.fixture
-def bv3() -> BitVector.BitVector:
+def bv3() -> BitVector:
     """Returns a 13-bit vector constructed from an integer (value 5678)."""
-    return BitVector.BitVector.from_int(5678)
+    return BitVector.from_int(5678)
 
 
 @pytest.mark.parametrize(
@@ -76,8 +76,8 @@ def test_comparison_operators(
         op: The comparison operator string ('==', '!=', '<', '<=', '>', '>=').
         expected: The expected boolean result of the comparison.
     """
-    left: BitVector.BitVector = request.getfixturevalue(left_name)
-    right: BitVector.BitVector = request.getfixturevalue(right_name)
+    left: BitVector = request.getfixturevalue(left_name)
+    right: BitVector = request.getfixturevalue(right_name)
     compare_func = OP_MAP[op]
     assert compare_func(left, right) is expected
 
@@ -108,14 +108,14 @@ def test_comparison_with_numeric_types(
     bv_val: int, other: int | float, op: ComparisonOp, expected: bool
 ) -> None:
     """Tests comparisons between BitVector and int/float."""
-    bv = BitVector.BitVector.from_int(bv_val)
+    bv = BitVector.from_int(bv_val)
     compare_func = OP_MAP[op]
     assert compare_func(bv, other) is expected
 
 
 def test_eq_ne_with_unsupported_types() -> None:
     """Tests that == and != work with any type and don't raise TypeError."""
-    bv = BitVector.BitVector.from_int(51)
+    bv = BitVector.from_int(51)
     assert (bv == "hello") is False
     assert (bv != "hello") is True
     assert (bv == [51]) is False
@@ -129,7 +129,7 @@ def test_order_comparisons_with_unsupported_types_raise_type_error(
     op: ComparisonOp,
 ) -> None:
     """Tests that <, <=, >, and >= raise TypeError for unsupported types."""
-    bv = BitVector.BitVector.from_int(51)
+    bv = BitVector.from_int(51)
     compare_func = OP_MAP[op]
     with pytest.raises(TypeError):
         compare_func(bv, "hello")
@@ -142,40 +142,38 @@ def test_order_comparisons_with_unsupported_types_raise_type_error(
 def test_eq_large_vectors() -> None:
     """Tests equality on multi-word large bitvectors."""
     # 1000-bit equal vectors
-    vec1 = BitVector.BitVector.from_bitstring("1010" * 250)
-    vec2 = BitVector.BitVector.from_bitstring("1010" * 250)
+    vec1 = BitVector.from_bitstring("1010" * 250)
+    vec2 = BitVector.from_bitstring("1010" * 250)
     assert vec1 == vec2
 
     # Differ in first word
-    vec3 = BitVector.BitVector.from_bitstring("0010" + "1010" * 249)
+    vec3 = BitVector.from_bitstring("0010" + "1010" * 249)
     assert vec1 != vec3
 
     # Differ in middle word (around bit 500)
     bits_mid = list("1010" * 250)
     bits_mid[500] = "0"
-    vec4 = BitVector.BitVector.from_bitstring("".join(bits_mid))
+    vec4 = BitVector.from_bitstring("".join(bits_mid))
     assert vec1 != vec4
 
     # Differ in last word (bit 999 is 0, flip to 1)
     bits_last = list("1010" * 250)
     bits_last[999] = "1"
-    vec5 = BitVector.BitVector.from_bitstring("".join(bits_last))
+    vec5 = BitVector.from_bitstring("".join(bits_last))
     assert vec1 != vec5
 
 
 def test_eq_with_differing_unused_bits() -> None:
     """Tests equality when unused bits in the last integer word differ."""
-    vec1 = BitVector.BitVector.from_bitstring("10101")
+    vec1 = BitVector.from_bitstring("10101")
     vec1_inv = ~vec1  # Bits: "01010", but unused high bits in last word are 1s
-    vec2 = BitVector.BitVector.from_bitstring(
-        "01010"
-    )  # Bits: "01010", unused high bits are 0s
+    vec2 = BitVector.from_bitstring("01010")  # Bits: "01010", unused high bits are 0s
     assert vec1_inv == vec2
     assert vec2 == vec1_inv
 
 
 def test_eq_empty_vectors() -> None:
     """Tests equality comparison on empty vectors (size 0)."""
-    vec1 = BitVector.BitVector(size=0)
-    vec2 = BitVector.BitVector(size=0)
+    vec1 = BitVector(size=0)
+    vec2 = BitVector(size=0)
     assert vec1 == vec2

--- a/tests/test_dunder.py
+++ b/tests/test_dunder.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, cast
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 @pytest.mark.parametrize(
@@ -33,8 +33,8 @@ def test_bitwise_dunder_operators(
         op: The bitwise operator string ('^', '&', or '|').
         expected: Expected output bitstring after applying the operator.
     """
-    bv_left = BitVector.BitVector.from_bitstring(left_str)
-    bv_right = BitVector.BitVector.from_bitstring(right_str)
+    bv_left = BitVector.from_bitstring(left_str)
+    bv_right = BitVector.from_bitstring(right_str)
     if op == "^":
         res = bv_left ^ bv_right
     elif op == "&":
@@ -63,32 +63,24 @@ def test_add(left_str: str, right_str: str, expected: str) -> None:
         right_str: Bitstring for the right operand.
         expected: Expected output bitstring after concatenation.
     """
-    left = (
-        BitVector.BitVector.from_bitstring(left_str)
-        if left_str
-        else BitVector.BitVector(size=0)
-    )
-    right = (
-        BitVector.BitVector.from_bitstring(right_str)
-        if right_str
-        else BitVector.BitVector(size=0)
-    )
+    left = BitVector.from_bitstring(left_str) if left_str else BitVector(size=0)
+    right = BitVector.from_bitstring(right_str) if right_str else BitVector(size=0)
     assert str(left + right) == expected
 
 
 def test_add_vector_type_fallback() -> None:
     """Tests __add__ fallback branches when self.vector is a list or tuple."""
-    bv2 = BitVector.BitVector.from_bitstring("010")
+    bv2 = BitVector.from_bitstring("010")
 
-    bv_tuple = BitVector.BitVector.from_bitstring("1001")
+    bv_tuple = BitVector.from_bitstring("1001")
     bv_tuple.vector = tuple(bv_tuple.vector)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     assert str(bv_tuple + bv2) == "1001010"
 
 
 def test_iadd() -> None:
     """Tests in-place concatenation dunder (__iadd__) and type validation."""
-    bv1 = BitVector.BitVector.from_bitstring("101")
-    bv2 = BitVector.BitVector.from_bitstring("010")
+    bv1 = BitVector.from_bitstring("101")
+    bv2 = BitVector.from_bitstring("010")
     bv1 += bv2
     assert str(bv1) == "101010"
 
@@ -114,8 +106,8 @@ def test_iadd() -> None:
 )
 def test_iadd_alignment_cases(s1: str, s2: str) -> None:
     """Tests __iadd__ across various word-alignment boundaries and sizes."""
-    bv1 = BitVector.BitVector.from_bitstring(s1) if s1 else BitVector.BitVector(size=0)
-    bv2 = BitVector.BitVector.from_bitstring(s2) if s2 else BitVector.BitVector(size=0)
+    bv1 = BitVector.from_bitstring(s1) if s1 else BitVector(size=0)
+    bv2 = BitVector.from_bitstring(s2) if s2 else BitVector(size=0)
     bv1 += bv2
     assert str(bv1) == s1 + s2
     assert len(bv1) == len(s1) + len(s2)
@@ -134,7 +126,7 @@ def test_iadd_alignment_cases(s1: str, s2: str) -> None:
 )
 def test_iadd_self_concatenation(s: str) -> None:
     """Tests in-place self-concatenation (bv += bv)."""
-    bv = BitVector.BitVector.from_bitstring(s)
+    bv = BitVector.from_bitstring(s)
     bv += bv
     assert str(bv) == s + s
     assert len(bv) == len(s) * 2
@@ -154,17 +146,13 @@ def test_invert(bitstring: str, expected: str) -> None:
         bitstring: Input bitstring to invert (empty string creates size=0).
         expected: Expected output bitstring after inversion.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert str(~bv) == expected
 
 
 def test_deepcopy() -> None:
     """Tests deep copying via copy.deepcopy, memoization, and fallbacks."""
-    bv = BitVector.BitVector.from_bitstring("10110")
+    bv = BitVector.from_bitstring("10110")
     bv_copy = copy.deepcopy(bv)
     assert str(bv_copy) == "10110"
     assert bv_copy is not bv
@@ -176,7 +164,7 @@ def test_deepcopy() -> None:
     # pylint: disable-next=unnecessary-dunder-call
     assert str(bv.__deepcopy__()) == "10110"
 
-    bv_tuple = BitVector.BitVector.from_bitstring("1001")
+    bv_tuple = BitVector.from_bitstring("1001")
     bv_tuple.vector = tuple(bv_tuple.vector)  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
     bv_tuple_copy = copy.deepcopy(bv_tuple)
     assert str(bv_tuple_copy) == "1001"
@@ -198,7 +186,7 @@ def test_lshift(shift: int, expected: str) -> None:
         shift: Number of bit positions to rotate left.
         expected: Expected output bitstring.
     """
-    bv = BitVector.BitVector.from_bitstring("1000")
+    bv = BitVector.from_bitstring("1000")
     res = bv << shift
     assert str(res) == expected
     assert str(bv) == "1000"
@@ -207,7 +195,7 @@ def test_lshift(shift: int, expected: str) -> None:
 
 def test_ilshift() -> None:
     """Tests in-place circular left shift dunder (__ilshift__ / <<=)."""
-    bv = BitVector.BitVector.from_bitstring("1000")
+    bv = BitVector.from_bitstring("1000")
     ref = bv
     bv <<= 1
     assert str(bv) == "0001"
@@ -225,7 +213,7 @@ def test_shift_empty_vector_raises_error(op: str) -> None:
     Args:
         op: The shift operator ('<<', '>>', '<<=', or '>>=').
     """
-    bv_empty = BitVector.BitVector(size=0)
+    bv_empty = BitVector(size=0)
     with pytest.raises(ValueError, match="Circular shift of an empty vector"):
         if op == "<<":
             _ = bv_empty << 1
@@ -253,7 +241,7 @@ def test_rshift(shift: int, expected: str) -> None:
         shift: Number of bit positions to rotate right.
         expected: Expected output bitstring.
     """
-    bv = BitVector.BitVector.from_bitstring("1000")
+    bv = BitVector.from_bitstring("1000")
     res = bv >> shift
     assert str(res) == expected
     assert str(bv) == "1000"
@@ -262,7 +250,7 @@ def test_rshift(shift: int, expected: str) -> None:
 
 def test_irshift() -> None:
     """Tests in-place circular right shift dunder (__irshift__ / >>=)."""
-    bv = BitVector.BitVector.from_bitstring("1000")
+    bv = BitVector.from_bitstring("1000")
     ref = bv
     bv >>= 1
     assert str(bv) == "0100"
@@ -281,7 +269,7 @@ def test_multibit_circular_shifts_large_vector(shift: int) -> None:
         shift: Number of bit positions to rotate.
     """
     s = "1" + "0" * 999
-    bv = BitVector.BitVector.from_bitstring(s)
+    bv = BitVector.from_bitstring(s)
 
     # Left shift and inverse left shift
     res_l = bv << shift
@@ -300,7 +288,7 @@ def test_multibit_circular_shifts_large_vector(shift: int) -> None:
 
 def test_multibit_circular_shifts_inplace() -> None:
     """Verifies in-place multi-bit circular shifts (__ilshift__, __irshift__)."""
-    bv_orig = BitVector.BitVector.from_bitstring("11010010101100" * 50)
+    bv_orig = BitVector.from_bitstring("11010010101100" * 50)
     bv = copy.deepcopy(bv_orig)
 
     bv <<= 353
@@ -391,16 +379,16 @@ def test_setitem_slice_assignment(
         valid_str: A bitstring of valid length for assignment.
         expected: Expected vector bitstring after assignment.
     """
-    bv = BitVector.BitVector.from_bitstring(initial)
+    bv = BitVector.from_bitstring(initial)
     with pytest.raises(ValueError, match=err_match):
-        bv[sl] = BitVector.BitVector(size=err_size)
-    bv[sl] = BitVector.BitVector.from_bitstring(valid_str)
+        bv[sl] = BitVector(size=err_size)
+    bv[sl] = BitVector.from_bitstring(valid_str)
     assert str(bv) == expected
 
 
 def test_setitem_index_assignment() -> None:
     """Tests __setitem__ with positive and negative integer indices."""
-    bv = BitVector.BitVector.from_bitstring("000")
+    bv = BitVector.from_bitstring("000")
     bv[1] = 1
     bv[-1] = 1
     assert str(bv) == "011"
@@ -410,7 +398,7 @@ def test_setitem_index_assignment() -> None:
 
 def test_setitem_slice_type_error() -> None:
     """Verifies slice assignment with a non-BitVector raises TypeError."""
-    bv = BitVector.BitVector.from_bitstring("000")
+    bv = BitVector.from_bitstring("000")
     with pytest.raises(
         TypeError,
         match="For slice assignment, the right hand side must be a BitVector",
@@ -420,8 +408,8 @@ def test_setitem_slice_type_error() -> None:
 
 def test_setitem_full_slice() -> None:
     """Tests __setitem__ when replacing the entire slice ([:])."""
-    bv = BitVector.BitVector.from_bitstring("1010")
-    bv[:] = BitVector.BitVector.from_bitstring("0101")
+    bv = BitVector.from_bitstring("1010")
+    bv[:] = BitVector.from_bitstring("0101")
     assert str(bv) == "1010"
 
 
@@ -439,17 +427,13 @@ def test_str(bitstring: str, expected: str) -> None:
         bitstring: Initial bitstring representation.
         expected: Expected string representation.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert str(bv) == expected
 
 
 def test_format() -> None:
     """Tests __format__ string and integer interpolation."""
-    bv = BitVector.BitVector.from_int(15, size=8)
+    bv = BitVector.from_int(15, size=8)
 
     # Test formatting with no specifier (defaults to str)
     assert f"{bv}" == "00001111"
@@ -471,7 +455,7 @@ def test_format() -> None:
     assert f"{bv:#X}" == "0XF"
 
     # Test formatting with grouping
-    bv2 = BitVector.BitVector.from_int(255, size=8)
+    bv2 = BitVector.from_int(255, size=8)
     assert f"{bv2:,}" == "255"
     assert f"{bv2:_}" == "255"
 
@@ -479,12 +463,12 @@ def test_format() -> None:
     assert f"{bv:f}" == "15.000000"
 
     # Test non-even multiples of 4 or 8
-    bv3 = BitVector.BitVector.from_int(15, size=7)
+    bv3 = BitVector.from_int(15, size=7)
     assert f"{bv3}" == "0001111"
     assert f"{bv3:x}" == "f"
 
     # Test formatting empty vector
-    bv_empty = BitVector.BitVector(size=0)
+    bv_empty = BitVector(size=0)
     assert f"{bv_empty}" == ""
     assert f"{bv_empty:10}" == "          "
     assert f"{bv_empty:d}" == "0"
@@ -507,11 +491,7 @@ def test_int(bitstring: str, expected: int) -> None:
         bitstring: Initial bitstring representation.
         expected: Expected integer conversion output.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert int(bv) == expected
 
 
@@ -543,11 +523,7 @@ def test_reversed(bitstring: str, expected_bits: list[int]) -> None:
         bitstring: Initial bitstring representation.
         expected_bits: Expected list of integer bits yielded in reverse order.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert list(reversed(bv)) == expected_bits
     # pylint: disable-next=unnecessary-dunder-call
     assert list(bv.__reversed__()) == expected_bits
@@ -563,7 +539,7 @@ def test_reversed_block_boundaries(size: int) -> None:
         size: Vector length in bits to test.
     """
     if size == 0:
-        bv = BitVector.BitVector(size=0)
+        bv = BitVector(size=0)
         assert not list(reversed(bv))
         # pylint: disable-next=unnecessary-dunder-call
         assert not list(bv.__reversed__())
@@ -571,7 +547,7 @@ def test_reversed_block_boundaries(size: int) -> None:
 
     bits = ["1" if (i % 7 == 0 or i == size - 1) else "0" for i in range(size)]
     bitstr = "".join(bits)
-    bv = BitVector.BitVector.from_bitstring(bitstr)
+    bv = BitVector.from_bitstring(bitstr)
     expected = [int(c) for c in reversed(bitstr)]
 
     assert list(reversed(bv)) == expected
@@ -596,16 +572,8 @@ def test_eq(left_str: str, right_str: str, expected: bool) -> None:
         right_str: Bitstring for the right operand.
         expected: Expected boolean equality result.
     """
-    left = (
-        BitVector.BitVector.from_bitstring(left_str)
-        if left_str
-        else BitVector.BitVector(size=0)
-    )
-    right = (
-        BitVector.BitVector.from_bitstring(right_str)
-        if right_str
-        else BitVector.BitVector(size=0)
-    )
+    left = BitVector.from_bitstring(left_str) if left_str else BitVector(size=0)
+    right = BitVector.from_bitstring(right_str) if right_str else BitVector(size=0)
     assert (left == right) is expected
 
 
@@ -624,8 +592,8 @@ def test_ne(left_str: str, right_str: str, expected: bool) -> None:
         right_str: Bitstring for the right operand.
         expected: Expected boolean inequality result.
     """
-    left = BitVector.BitVector.from_bitstring(left_str)
-    right = BitVector.BitVector.from_bitstring(right_str)
+    left = BitVector.from_bitstring(left_str)
+    right = BitVector.from_bitstring(right_str)
     assert (left != right) is expected
 
 
@@ -657,8 +625,8 @@ def test_relational_operators(
         op: Relational operator string ('<', '<=', '>', '>=').
         expected: Expected boolean comparison result.
     """
-    bv1 = BitVector.BitVector.from_int(val1, size=8)
-    bv2 = BitVector.BitVector.from_int(val2, size=8)
+    bv1 = BitVector.from_int(val1, size=8)
+    bv2 = BitVector.from_int(val2, size=8)
     if op == "<":
         res = bv1 < bv2
     elif op == "<=":
@@ -686,8 +654,8 @@ def test_contains(pattern: str, expected_in: bool) -> None:
         pattern: The bitstring pattern to search for.
         expected_in: True if pattern is found in the vector, otherwise False.
     """
-    bv = BitVector.BitVector.from_bitstring("110100")
-    sub_bv = BitVector.BitVector.from_bitstring(pattern)
+    bv = BitVector.from_bitstring("110100")
+    sub_bv = BitVector.from_bitstring(pattern)
     assert (sub_bv in bv) is expected_in
 
 
@@ -708,11 +676,7 @@ def test_contains_invalid_args_raises_error(
         pattern_str: The bitstring for the substring pattern vector.
         err_match: The expected error message substring.
     """
-    target = (
-        BitVector.BitVector.from_bitstring(target_str)
-        if target_str
-        else BitVector.BitVector(size=0)
-    )
-    pattern = BitVector.BitVector.from_bitstring(pattern_str)
+    target = BitVector.from_bitstring(target_str) if target_str else BitVector(size=0)
+    pattern = BitVector.from_bitstring(pattern_str)
     with pytest.raises(ValueError, match=err_match):
         _ = pattern in target

--- a/tests/test_get_set.py
+++ b/tests/test_get_set.py
@@ -5,12 +5,12 @@ from typing import Any, cast
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 def test_setitem_type_error() -> None:
     """Verifies that non-integer bit assignment raises TypeError."""
-    bv = BitVector.BitVector(size=5)
+    bv = BitVector(size=5)
     with pytest.raises(TypeError, match="pos must be an integer"):
         bv[cast(Any, "0")] = 1
 
@@ -32,7 +32,7 @@ def test_getitem_type_error(invalid_pos: Any) -> None:
     Args:
         invalid_pos: An object that is neither an integer nor a slice.
     """
-    bv = BitVector.BitVector(size=5)
+    bv = BitVector(size=5)
     with pytest.raises(TypeError, match="pos must be an integer or slice"):
         _ = bv[invalid_pos]  # type: ignore[index]
 
@@ -53,7 +53,7 @@ def test_setitem_raises_error(index: int, val: int, err_match: str) -> None:
         val: The bit value to assign (should be 0 or 1).
         err_match: The expected error message substring.
     """
-    bv = BitVector.BitVector.from_bitstring("00000")
+    bv = BitVector.from_bitstring("00000")
     with pytest.raises(ValueError, match=err_match):
         bv[index] = val
 
@@ -78,7 +78,7 @@ def test_setitem_valid(
         val: The bit value (0 or 1) to assign.
         expected: The expected vector bitstring after modification.
     """
-    bv = BitVector.BitVector.from_bitstring(initial)
+    bv = BitVector.from_bitstring(initial)
     bv[cast(Any, index)] = val
     assert str(bv) == expected
 
@@ -90,7 +90,7 @@ def test_getitem_int_raises_error(index: int) -> None:
     Args:
         index: The out-of-bounds index to query.
     """
-    bv = BitVector.BitVector.from_bitstring("10110")
+    bv = BitVector.from_bitstring("10110")
     with pytest.raises(ValueError, match="index range error"):
         bv[index]  # pylint: disable=pointless-statement
 
@@ -111,7 +111,7 @@ def test_getitem_int(index: int, expected: int) -> None:
         index: The bit index to query.
         expected: The expected integer bit value (0 or 1).
     """
-    bv = BitVector.BitVector.from_bitstring("10110")
+    bv = BitVector.from_bitstring("10110")
     assert bv[index] == expected
 
 
@@ -138,11 +138,7 @@ def test_getitem_slice(initial: str, sl: slice, expected: str) -> None:
         sl: The slice object defining the range to extract.
         expected: Expected bitstring representation of the extracted slice.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(initial)
-        if initial
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(initial) if initial else BitVector(size=0)
     assert str(bv[sl]) == expected
 
 
@@ -150,7 +146,7 @@ def test_getitem_word_aligned_and_unaligned_slicing() -> None:
     """Tests word-aligned and unaligned slicing on multi-word BitVectors."""
     # Construct a 200-bit vector with a repeating bit pattern
     pattern = "11001010" * 25  # 200 bits
-    bv = BitVector.BitVector.from_bitstring(pattern)
+    bv = BitVector.from_bitstring(pattern)
 
     # 1. Word-aligned slice starting at index 0 (64 bits = 1 word)
     assert str(bv[0:64]) == pattern[0:64]
@@ -190,16 +186,16 @@ def test_getitem_slice_raises_error(sl: slice) -> None:
     Args:
         sl: The invalid slice object to test on a 5-bit vector.
     """
-    bv = BitVector.BitVector.from_bitstring("10110")
+    bv = BitVector.from_bitstring("10110")
     with pytest.raises(ValueError, match="illegal slice index values"):
         _ = bv[sl]
 
 
 def test_bitvector_iterator() -> None:
     """Tests sequential iteration over bits in a BitVector."""
-    bv = BitVector.BitVector.from_bitstring("101")
+    bv = BitVector.from_bitstring("101")
     it = iter(bv)
     assert isinstance(it, Iterator)
     assert iter(it) is it
     assert list(it) == [1, 0, 1]
-    assert not list(iter(BitVector.BitVector(size=0)))
+    assert not list(iter(BitVector(size=0)))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-import BitVector
+from BitVector import BitVector, __version__
 
 
 class ZeroHex:
@@ -23,14 +23,14 @@ class ZeroHex:
 def test_positional_args_error() -> None:
     """Verifies that passing positional arguments raises TypeError."""
     with pytest.raises(TypeError, match="takes 1 positional argument"):
-        BitVector.BitVector(123)  # type: ignore[misc,arg-type]  # ty: ignore[too-many-positional-arguments]
+        BitVector(123)  # type: ignore[misc,arg-type]  # ty: ignore[too-many-positional-arguments]
 
 
 def test_invalid_keyword_error() -> None:
     """Verifies passing unexpected keyword arguments raises TypeError."""
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         # pylint: disable-next=unexpected-keyword-arg
-        BitVector.BitVector(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+        BitVector(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
 
 
 @pytest.mark.parametrize(
@@ -54,7 +54,7 @@ def test_constructor_conflicting_args_raises_error(
         err_match: The expected regex error message pattern.
     """
     with pytest.raises(ValueError, match=err_match):
-        BitVector.BitVector(**kwargs)
+        BitVector(**kwargs)
 
 
 @pytest.mark.parametrize(
@@ -75,7 +75,7 @@ def test_constructor_legacy_kwargs_raise_type_error(
         err_match: The expected regex error message pattern.
     """
     with pytest.raises(TypeError, match=err_match):
-        BitVector.BitVector(**kwargs)
+        BitVector(**kwargs)
 
 
 @pytest.mark.parametrize(
@@ -97,41 +97,41 @@ def test_constructor_valid_kwargs(
         expected_str: Expected bitstring representation.
         expected_size: Expected integer bit vector size.
     """
-    bv = BitVector.BitVector(**kwargs)
+    bv = BitVector(**kwargs)
     assert str(bv) == expected_str
     assert bv._size == expected_size
 
 
 def test_from_string() -> None:
     """Tests initializing BitVector from a string via the from_string method."""
-    bv = BitVector.BitVector.from_string("A")
+    bv = BitVector.from_string("A")
     assert str(bv) == "01000001"
 
-    bv2 = BitVector.BitVector.from_string("A\x05")
+    bv2 = BitVector.from_string("A\x05")
     assert bv2._size == 16
 
 
 def test_from_hex() -> None:
     """Tests initializing BitVector from a hex string via the from_hex method."""
-    bv = BitVector.BitVector.from_hex("0FaE")
+    bv = BitVector.from_hex("0FaE")
     assert str(bv) == "0000111110101110"
     assert bv._size == 16
 
-    bv2 = BitVector.BitVector.from_hex("")
+    bv2 = BitVector.from_hex("")
     assert str(bv2) == ""
     assert bv2._size == 0
 
 
 def test_intVal_zero_hex_helper() -> None:
     """Tests intVal zero evaluation using the ZeroHex helper class."""
-    bv = BitVector.BitVector.from_int(
+    bv = BitVector.from_int(
         val=ZeroHex(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         size=0,
     )
     assert bv._size == 0
     assert str(bv) == ""
 
-    bv2 = BitVector.BitVector.from_int(
+    bv2 = BitVector.from_int(
         val=ZeroHex(),  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         size=5,
     )
@@ -141,60 +141,60 @@ def test_intVal_zero_hex_helper() -> None:
 
 def test_from_int() -> None:
     """Tests initializing BitVector via the from_int class method."""
-    bv = BitVector.BitVector.from_int(5)
+    bv = BitVector.from_int(5)
     assert str(bv) == "101"
     assert bv._size == 3
 
-    bv_padded = BitVector.BitVector.from_int(5, size=8)
+    bv_padded = BitVector.from_int(5, size=8)
     assert str(bv_padded) == "00000101"
     assert bv_padded._size == 8
 
-    bv_zero = BitVector.BitVector.from_int(0)
+    bv_zero = BitVector.from_int(0)
     assert str(bv_zero) == "0"
     assert bv_zero._size == 1
 
-    bv_zero_padded = BitVector.BitVector.from_int(0, size=4)
+    bv_zero_padded = BitVector.from_int(0, size=4)
     assert str(bv_zero_padded) == "0000"
     assert bv_zero_padded._size == 4
 
     with pytest.raises(
         ValueError, match="The value specified for size must be at least"
     ):
-        BitVector.BitVector.from_int(255, size=2)
+        BitVector.from_int(255, size=2)
 
     with pytest.raises(ValueError, match="val must be non-negative"):
-        BitVector.BitVector.from_int(-5)
+        BitVector.from_int(-5)
 
 
 def test_from_bytes() -> None:
     """Tests initializing BitVector via the from_bytes class method."""
-    bv = BitVector.BitVector.from_bytes(b"\x00\xff")
+    bv = BitVector.from_bytes(b"\x00\xff")
     assert str(bv) == "0000000011111111"
     assert bv._size == 16
 
-    bv_empty = BitVector.BitVector.from_bytes(b"")
+    bv_empty = BitVector.from_bytes(b"")
     assert str(bv_empty) == ""
     assert bv_empty._size == 0
 
 
 def test_from_bitstring() -> None:
     """Tests initializing BitVector via the from_bitstring class method."""
-    bv = BitVector.BitVector.from_bitstring("1101")
+    bv = BitVector.from_bitstring("1101")
     assert str(bv) == "1101"
     assert bv._size == 4
 
-    bv_empty = BitVector.BitVector.from_bitstring("")
+    bv_empty = BitVector.from_bitstring("")
     assert str(bv_empty) == ""
     assert bv_empty._size == 0
 
 
 def test_from_bitlist() -> None:
     """Tests initializing BitVector via the from_bitlist class method."""
-    bv = BitVector.BitVector.from_bitlist([1, 0, 1, 0])
+    bv = BitVector.from_bitlist([1, 0, 1, 0])
     assert str(bv) == "1010"
     assert bv._size == 4
 
-    bv_empty = BitVector.BitVector.from_bitlist([])
+    bv_empty = BitVector.from_bitlist([])
     assert str(bv_empty) == ""
     assert bv_empty._size == 0
 
@@ -207,5 +207,5 @@ def test_version() -> None:
         r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
         r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
     )
-    assert isinstance(BitVector.__version__, str)
-    assert re.fullmatch(semver_pattern, BitVector.__version__) is not None
+    assert isinstance(__version__, str)
+    assert re.fullmatch(semver_pattern, __version__) is not None

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -4,12 +4,12 @@ import copy
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 def test_divide_into_two_raises_error() -> None:
     """Verifies dividing a vector with an odd number of bits raises ValueError."""
-    bv_odd = BitVector.BitVector.from_bitstring("101")
+    bv_odd = BitVector.from_bitstring("101")
     with pytest.raises(ValueError, match="must have even num bits"):
         bv_odd.divide_into_two()
 
@@ -31,11 +31,7 @@ def test_divide_into_two(
         expected_left: Expected bitstring of the left half vector.
         expected_right: Expected bitstring of the right half vector.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     left, right = bv.divide_into_two()
     assert str(left) == expected_left
     assert str(right) == expected_right
@@ -57,7 +53,7 @@ def test_permute_raises_error(
         perm_list: List of target bit indices for permutation.
         err_match: Expected error message pattern.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match=err_match):
         bv.permute(perm_list)
 
@@ -77,7 +73,7 @@ def test_permute(bitstring: str, perm_list: list[int], expected: str) -> None:
         perm_list: List of target bit indices for permutation.
         expected: Expected output vector bitstring.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     permuted = bv.permute(perm_list)
     assert str(permuted) == expected
 
@@ -99,14 +95,14 @@ def test_unpermute_raises_error(
         perm_list: List of permutation indices.
         err_match: Expected error message pattern.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match=err_match):
         bv.unpermute(perm_list)
 
 
 def test_unpermute() -> None:
     """Tests round-trip permutation and unpermutation."""
-    bv_orig = BitVector.BitVector.from_bitstring("11001010")
+    bv_orig = BitVector.from_bitstring("11001010")
     p_list = [7, 6, 5, 4, 3, 2, 1, 0]
     permuted = bv_orig.permute(p_list)
     unpermuted = permuted.unpermute(p_list)
@@ -132,7 +128,7 @@ def test_one_bit_shifts(method_name: str, bitstring: str, expected: str) -> None
         bitstring: Initial vector bitstring representation.
         expected: Expected output vector bitstring after mutation.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     method = getattr(bv, method_name)
     method()
     assert str(bv) == expected
@@ -155,7 +151,7 @@ def test_shift_left_right(direction: str, shift_amount: int, expected: str) -> N
         shift_amount: Number of bit positions to shift.
         expected: Expected output vector bitstring.
     """
-    bv = BitVector.BitVector.from_bitstring("101101")
+    bv = BitVector.from_bitstring("101101")
     if direction == "left":
         res = bv.shift_left(shift_amount)
     else:
@@ -188,7 +184,7 @@ def test_shift_left_comprehensive(
         shift_amount: Number of positions to shift left.
         expected_bitstring: Expected bitstring representation after shifting.
     """
-    bv = BitVector.BitVector.from_bitstring(initial_bitstring)
+    bv = BitVector.from_bitstring(initial_bitstring)
     res = bv.shift_left(shift_amount)
     assert res is bv
     assert str(bv) == expected_bitstring
@@ -218,7 +214,7 @@ def test_shift_right_comprehensive(
         shift_amount: Number of positions to shift right.
         expected_bitstring: Expected bitstring representation after shifting.
     """
-    bv = BitVector.BitVector.from_bitstring(initial_bitstring)
+    bv = BitVector.from_bitstring(initial_bitstring)
     res = bv.shift_right(shift_amount)
     assert res is bv
     assert str(bv) == expected_bitstring
@@ -226,7 +222,7 @@ def test_shift_right_comprehensive(
 
 def test_shift_right_extended_vector() -> None:
     """Verifies shift_right clears trailing excess words when vector storage is over-allocated."""
-    bv = BitVector.BitVector.from_bitstring("1" * 65)
+    bv = BitVector.from_bitstring("1" * 65)
     bv.vector.append(999)
     res = bv.shift_right(1)
     assert res is bv
@@ -264,11 +260,7 @@ def test_padding(
         input_str: Input bitstring to construct vector.
         expected_str: Expected output vector bitstring.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(input_str)
-        if input_str
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(input_str) if input_str else BitVector(size=0)
     if direction == "left":
         resized = bv._resize_pad_from_left(pad_count)
         assert str(resized) == expected_str
@@ -281,7 +273,7 @@ def test_padding(
 
 def test_reset_raises_error() -> None:
     """Verifies calling reset with an invalid bit value raises ValueError."""
-    bv = BitVector.BitVector.from_bitstring("101")
+    bv = BitVector.from_bitstring("101")
     with pytest.raises(ValueError, match="Incorrect reset argument"):
         bv.reset(2)
 
@@ -300,7 +292,7 @@ def test_reset(val: int, expected: str) -> None:
         val: The bit value (0 or 1) to reset all bits to.
         expected: Expected output vector bitstring.
     """
-    bv = BitVector.BitVector.from_bitstring("101")
+    bv = BitVector.from_bitstring("101")
     res = bv.reset(val)
     assert str(bv) == expected
     assert res is bv
@@ -309,12 +301,12 @@ def test_reset(val: int, expected: str) -> None:
 def test_reset_coverage() -> None:
     """Tests reset with vector size multiple of word size and size 0."""
     # rem == 0, len(self.vector) > 0
-    bv_64 = BitVector.BitVector(size=64)
+    bv_64 = BitVector(size=64)
     bv_64.reset(1)
     assert str(bv_64) == "1" * 64
 
     # rem == 0, len(self.vector) == 0
-    bv_0 = BitVector.BitVector(size=0)
+    bv_0 = BitVector(size=0)
     bv_0.reset(1)
     assert str(bv_0) == ""
 
@@ -334,11 +326,7 @@ def test_bit_count(bitstring: str, expected_count: int) -> None:
         bitstring: Initial vector bitstring representation.
         expected_count: Expected number of bits set to 1.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert bv.bit_count() == expected_count
 
 
@@ -359,11 +347,7 @@ def test_bit_count_sparse(bitstring: str, expected_count: int) -> None:
         bitstring: Initial vector bitstring representation.
         expected_count: Expected number of bits set to 1.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert bv.bit_count_sparse() == expected_count
 
 
@@ -377,7 +361,7 @@ def test_bit_count_unmasked_inversion(size: int) -> None:
     Args:
         size: Vector length in bits.
     """
-    bv = BitVector.BitVector(size=size)
+    bv = BitVector(size=size)
     inv_bv = ~bv
     assert inv_bv.bit_count() == size
     assert inv_bv.bit_count_sparse() == size
@@ -385,7 +369,7 @@ def test_bit_count_unmasked_inversion(size: int) -> None:
 
 def test_set_value() -> None:
     """Tests mutating an existing BitVector via set_value."""
-    bv = BitVector.BitVector.from_int(7, size=16)
+    bv = BitVector.from_int(7, size=16)
     bv.set_value(bitlist=[1, 0, 1, 1, 0, 1])
     assert str(bv) == "101101"
 
@@ -395,14 +379,14 @@ def test_set_value() -> None:
 
 def test_set_value_positional_args_error() -> None:
     """Verifies that passing positional arguments to set_value raises TypeError."""
-    bv = BitVector.BitVector.from_int(7, size=16)
+    bv = BitVector.from_int(7, size=16)
     with pytest.raises(TypeError, match="takes 1 positional argument"):
         bv.set_value(123)  # type: ignore[misc,arg-type]  # ty: ignore[too-many-positional-arguments]
 
 
 def test_set_value_invalid_keyword_error() -> None:
     """Verifies passing unexpected keyword arguments to set_value raises TypeError."""
-    bv = BitVector.BitVector.from_int(7, size=16)
+    bv = BitVector.from_int(7, size=16)
     with pytest.raises(TypeError, match="unexpected keyword argument"):
         # pylint: disable-next=unexpected-keyword-arg
         bv.set_value(invalid_param=123)  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
@@ -428,8 +412,8 @@ def test_distance_metrics_raise_error(
         bv2_str: Bitstring for the second vector.
         err_match: Expected error message substring.
     """
-    bv1 = BitVector.BitVector.from_bitstring(bv1_str)
-    bv2 = BitVector.BitVector.from_bitstring(bv2_str)
+    bv1 = BitVector.from_bitstring(bv1_str)
+    bv2 = BitVector.from_bitstring(bv2_str)
     method = getattr(bv1, method_name)
     with pytest.raises(ValueError, match=err_match):
         method(bv2)
@@ -454,8 +438,8 @@ def test_distance_metrics(
         bv2_str: Bitstring for the second vector.
         expected: Expected distance or similarity numerical result.
     """
-    bv1 = BitVector.BitVector.from_bitstring(bv1_str)
-    bv2 = BitVector.BitVector.from_bitstring(bv2_str)
+    bv1 = BitVector.from_bitstring(bv1_str)
+    bv2 = BitVector.from_bitstring(bv2_str)
     method = getattr(bv1, method_name)
     res = method(bv2)
     if isinstance(expected, float):
@@ -466,7 +450,7 @@ def test_distance_metrics(
 
 def test_next_set_bit_raises_error() -> None:
     """Verifies calling next_set_bit with a negative index raises ValueError."""
-    bv = BitVector.BitVector.from_bitstring("00000000000001")
+    bv = BitVector.from_bitstring("00000000000001")
     with pytest.raises(ValueError, match="from_index must be nonnegative"):
         bv.next_set_bit(-1)
 
@@ -487,19 +471,19 @@ def test_next_set_bit(bitstring: str, start_idx: int, expected_idx: int) -> None
         start_idx: The starting index for scanning.
         expected_idx: Expected index of the next set bit (-1 if none found).
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     assert bv.next_set_bit(start_idx) == expected_idx
 
 
 def test_next_set_bit_out_of_bounds() -> None:
     """Verifies next_set_bit raises IndexError when from_index >= size."""
-    bv_empty = BitVector.BitVector(size=0)
+    bv_empty = BitVector(size=0)
     with pytest.raises(IndexError, match="from_index out of range"):
         bv_empty.next_set_bit(0)
     with pytest.raises(IndexError, match="from_index out of range"):
         bv_empty.next_set_bit(5)
 
-    bv_10 = BitVector.BitVector(size=10)
+    bv_10 = BitVector(size=10)
     with pytest.raises(IndexError, match="from_index out of range"):
         bv_10.next_set_bit(10)
     with pytest.raises(IndexError, match="from_index out of range"):
@@ -510,7 +494,7 @@ def test_next_set_bit_out_of_bounds() -> None:
 
 def test_next_set_bit_ignores_padding() -> None:
     """Verifies next_set_bit ignores non-zero padding bits beyond size."""
-    bv = BitVector.BitVector(size=10)
+    bv = BitVector(size=10)
     # Manually set padding bits in the single word (bits 10..63)
     bv.vector[0] = 0b11111111110000000000
     assert bv.next_set_bit(0) == -1
@@ -518,7 +502,7 @@ def test_next_set_bit_ignores_padding() -> None:
     with pytest.raises(IndexError, match="from_index out of range"):
         bv.next_set_bit(10)
 
-    bv_70 = BitVector.BitVector(size=70)
+    bv_70 = BitVector(size=70)
     # Set padding bit at index 75 (bit 11 in word 1)
     bv_70.vector[1] = 1 << 11
     assert bv_70.next_set_bit(0) == -1
@@ -529,14 +513,14 @@ def test_next_set_bit_ignores_padding() -> None:
 
 def test_rank_of_bit_set_at_index_raises_error() -> None:
     """Verifies rank query on an unset bit raises ValueError."""
-    bv = BitVector.BitVector.from_bitstring("01010101011100")
+    bv = BitVector.from_bitstring("01010101011100")
     with pytest.raises(ValueError, match="the arg bit not set"):
         bv.rank_of_bit_set_at_index(0)
 
 
 def test_rank_of_bit_set_at_index() -> None:
     """Tests calculating the rank (number of preceding 1 bits) of a set bit."""
-    bv = BitVector.BitVector.from_bitstring("01010101011100")
+    bv = BitVector.from_bitstring("01010101011100")
     assert bv.rank_of_bit_set_at_index(10) == 6
 
 
@@ -558,7 +542,7 @@ def test_is_power_of_2(bitstring: str, sparse: bool, expected: bool) -> None:
         sparse: Whether to use is_power_of_2_sparse.
         expected: Expected boolean result.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     res = bv.is_power_of_2_sparse() if sparse else bv.is_power_of_2()
     assert res is expected
 
@@ -577,54 +561,50 @@ def test_reverse(bitstring: str, expected: str) -> None:
         bitstring: Initial vector bitstring representation.
         expected: Expected bitstring representation after reversal.
     """
-    bv = (
-        BitVector.BitVector.from_bitstring(bitstring)
-        if bitstring
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     assert str(bv.reverse()) == expected
 
 
 def test_gcd() -> None:
     """Tests greatest common divisor calculation between two vectors."""
-    bv1 = BitVector.BitVector.from_bitstring("01100110")  # 102
-    bv2 = BitVector.BitVector.from_bitstring("011010")  # 26
+    bv1 = BitVector.from_bitstring("01100110")  # 102
+    bv2 = BitVector.from_bitstring("011010")  # 26
     assert int(bv1.gcd(bv2)) == 2
     assert int(bv2.gcd(bv1)) == 2
 
 
 def test_multiplicative_inverse() -> None:
     """Tests modular multiplicative inverse existence and calculation."""
-    bv_mod = BitVector.BitVector.from_int(32)
-    bv_has_mi = BitVector.BitVector.from_int(17)
+    bv_mod = BitVector.from_int(32)
+    bv_has_mi = BitVector.from_int(17)
     res = bv_has_mi.multiplicative_inverse(bv_mod)
     assert res is not None
     assert int(res) == 17
 
-    bv_no_mi = BitVector.BitVector.from_int(2)
+    bv_no_mi = BitVector.from_int(2)
     res_none = bv_no_mi.multiplicative_inverse(bv_mod)
     assert res_none is None
 
 
 def test_gf_multiply() -> None:
     """Tests polynomial multiplication over GF(2)."""
-    a = BitVector.BitVector.from_bitstring("0110001")
-    b = BitVector.BitVector.from_bitstring("0110")
+    a = BitVector.from_bitstring("0110001")
+    b = BitVector.from_bitstring("0110")
     c = a.gf_multiply(b)
     assert str(c) == "00010100110"
 
-    b_zero = BitVector.BitVector.from_bitstring("0000")
+    b_zero = BitVector.from_bitstring("0000")
     c_zero = a.gf_multiply(b_zero)
     assert int(c_zero) == 0
 
 
 def test_gf_divide_by_modulus() -> None:
     """Tests polynomial division by modulus over GF(2^n) and error checking."""
-    mod = BitVector.BitVector.from_bitstring("100011011")  # AES modulus
+    mod = BitVector.from_bitstring("100011011")  # AES modulus
     n = 8
-    a = BitVector.BitVector.from_bitstring("11100010110001")
+    a = BitVector.from_bitstring("11100010110001")
 
-    mod_long = BitVector.BitVector.from_bitstring("1" * 15)
+    mod_long = BitVector.from_bitstring("1" * 15)
     with pytest.raises(ValueError, match="Modulus bit pattern too long"):
         a.gf_divide_by_modulus(mod_long, n)
 
@@ -636,32 +616,32 @@ def test_gf_divide_by_modulus() -> None:
     _, r_eq = a_equal.gf_divide_by_modulus(mod, n)
     assert int(r_eq) == 0
 
-    _, r_zero = BitVector.BitVector.from_bitstring("0").gf_divide_by_modulus(
-        BitVector.BitVector.from_bitstring("1"), 1
+    _, r_zero = BitVector.from_bitstring("0").gf_divide_by_modulus(
+        BitVector.from_bitstring("1"), 1
     )
     assert int(r_zero) == 0
 
 
 def test_gf_multiply_modular() -> None:
     """Tests modular polynomial multiplication over GF(2^8)."""
-    mod = BitVector.BitVector.from_bitstring("100011011")  # AES modulus
+    mod = BitVector.from_bitstring("100011011")  # AES modulus
     n = 8
-    a = BitVector.BitVector.from_bitstring("0110001")
-    b = BitVector.BitVector.from_bitstring("0110")
+    a = BitVector.from_bitstring("0110001")
+    b = BitVector.from_bitstring("0110")
     c = a.gf_multiply_modular(b, mod, n)
     assert str(c) == "10100110"
 
 
 def test_gf_mi() -> None:
     """Tests multiplicative inverse over GF(2^n) and non-existent fallback."""
-    mod = BitVector.BitVector.from_bitstring("100011011")
+    mod = BitVector.from_bitstring("100011011")
     n = 8
-    a = BitVector.BitVector.from_bitstring("00110011")
+    a = BitVector.from_bitstring("00110011")
     mi = a.gf_MI(mod, n)
     assert str(mi) == "01101100"
 
-    mod_no_mi = BitVector.BitVector.from_bitstring("1010")
-    a_no_mi = BitVector.BitVector.from_bitstring("0010")
+    mod_no_mi = BitVector.from_bitstring("1010")
+    a_no_mi = BitVector.from_bitstring("0010")
     res_no_mi = a_no_mi.gf_MI(mod_no_mi, 3)
     assert isinstance(res_no_mi, str)
     assert res_no_mi == "NO MI. However, the GCD of 0010 and 1010 is 010"
@@ -687,36 +667,32 @@ def test_runs(
         expected: Expected list of bit run strings.
     """
     if bitstring is not None:
-        bv = (
-            BitVector.BitVector.from_bitstring(bitstring)
-            if bitstring
-            else BitVector.BitVector(size=0)
-        )
+        bv = BitVector.from_bitstring(bitstring) if bitstring else BitVector(size=0)
     elif bitlist is not None:
-        bv = BitVector.BitVector(bitlist=list(bitlist))
+        bv = BitVector(bitlist=list(bitlist))
     else:
-        bv = BitVector.BitVector(size=0)
+        bv = BitVector(size=0)
     assert bv.runs() == expected
 
 
 def test_test_for_primality() -> None:
     """Tests Miller-Rabin and small-probe primality verification."""
-    assert BitVector.BitVector.from_int(1, size=8).test_for_primality() == 0
-    assert BitVector.BitVector.from_int(2, size=8).test_for_primality() == 1
-    assert BitVector.BitVector.from_int(17, size=8).test_for_primality() == 1
-    assert BitVector.BitVector.from_int(25, size=8).test_for_primality() == 0
+    assert BitVector.from_int(1, size=8).test_for_primality() == 0
+    assert BitVector.from_int(2, size=8).test_for_primality() == 1
+    assert BitVector.from_int(17, size=8).test_for_primality() == 1
+    assert BitVector.from_int(25, size=8).test_for_primality() == 0
 
-    prob_19 = BitVector.BitVector.from_int(19, size=16).test_for_primality()
+    prob_19 = BitVector.from_int(19, size=16).test_for_primality()
     assert prob_19 > 0.99
-    prob_41 = BitVector.BitVector.from_int(41, size=16).test_for_primality()
+    prob_41 = BitVector.from_int(41, size=16).test_for_primality()
     assert prob_41 > 0.99
 
-    assert BitVector.BitVector.from_int(361, size=16).test_for_primality() == 0
+    assert BitVector.from_int(361, size=16).test_for_primality() == 0
 
 
 def test_gen_random_bits(mocker) -> None:
     """Tests random bit vector generation with forced odd integer result."""
-    bv = BitVector.BitVector(size=0).gen_random_bits(32)
+    bv = BitVector(size=0).gen_random_bits(32)
     assert bv._size == 32
     # Check least significant bit is 1
     assert int(bv) & 1 == 1
@@ -725,17 +701,17 @@ def test_gen_random_bits(mocker) -> None:
     assert bv[1] == 1
 
     # Check that it returns different values on consecutive calls
-    bv2 = BitVector.BitVector(size=0).gen_random_bits(32)
+    bv2 = BitVector(size=0).gen_random_bits(32)
     assert bv != bv2
 
     # Check that secrets.randbits is called
     mock_randbits = mocker.patch("BitVector.BitVector.secrets.randbits", return_value=0)
-    bv_mock = BitVector.BitVector(size=0).gen_random_bits(32)
+    bv_mock = BitVector(size=0).gen_random_bits(32)
     mock_randbits.assert_called_once_with(32)
     assert int(bv_mock) == (1 | (1 << 31) | (2 << 29))
 
 
 def test_min_canonical() -> None:
     """Tests finding the lexicographically smallest circular rotation."""
-    bv = BitVector.BitVector.from_bitstring("1101")
+    bv = BitVector.from_bitstring("1101")
     assert str(bv.min_canonical()) == "0111"

--- a/tests/test_permutations.py
+++ b/tests/test_permutations.py
@@ -4,19 +4,19 @@ from typing import Literal
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 @pytest.fixture
-def bv1() -> BitVector.BitVector:
+def bv1() -> BitVector:
     """Returns a 7-bit vector constructed from a bitlist ('1001101')."""
-    return BitVector.BitVector(bitlist=[1, 0, 0, 1, 1, 0, 1])
+    return BitVector(bitlist=[1, 0, 0, 1, 1, 0, 1])
 
 
 @pytest.fixture
-def bv2() -> BitVector.BitVector:
+def bv2() -> BitVector:
     """Returns a 7-bit vector constructed from a bitlist ('1010011')."""
-    return BitVector.BitVector(bitlist=[1, 0, 1, 0, 0, 1, 1])
+    return BitVector(bitlist=[1, 0, 1, 0, 0, 1, 1])
 
 
 @pytest.mark.parametrize(
@@ -46,7 +46,7 @@ def test_permutations(
         perm_list: A sequence of integer indices specifying bit ordering.
         expected: The expected bitstring representation after operation.
     """
-    bv: BitVector.BitVector = request.getfixturevalue(bv_name)
+    bv: BitVector = request.getfixturevalue(bv_name)
     if op == "permute":
         result = bv.permute(perm_list)
     elif op == "unpermute":
@@ -54,12 +54,12 @@ def test_permutations(
     else:
         raise ValueError(f"Unsupported operator: {op}")
 
-    assert result == BitVector.BitVector.from_bitstring(expected)
+    assert result == BitVector.from_bitstring(expected)
 
 
 @pytest.mark.parametrize("op", ["permute", "unpermute"])
 def test_permutation_out_of_bounds_raises_error(
-    bv1: BitVector.BitVector, op: Literal["permute", "unpermute"]
+    bv1: BitVector, op: Literal["permute", "unpermute"]
 ) -> None:
     """Verifies out-of-bounds indices in permutation lists raise ValueError.
 
@@ -74,7 +74,7 @@ def test_permutation_out_of_bounds_raises_error(
             _ = bv1.unpermute([7, 0, 1, 2, 3, 4, 5])
 
 
-def test_unpermute_bad_size_raises_error(bv1: BitVector.BitVector) -> None:
+def test_unpermute_bad_size_raises_error(bv1: BitVector) -> None:
     """Verifies unpermute raises ValueError when list size mismatches.
 
     Args:

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -5,7 +5,7 @@ import copy
 import hypothesis.strategies as st  # type: ignore[import-not-found]
 from hypothesis import given  # type: ignore[import-not-found]
 
-import BitVector
+from BitVector import BitVector
 
 
 @given(
@@ -23,8 +23,8 @@ def test_addition_after_inversion(bits1: str, bits2: str) -> None:
         bits2: Bitstring representation for the second operand.
     """
     expected = "".join("1" if b == "0" else "0" for b in bits1) + bits2
-    bv1 = BitVector.BitVector.from_bitstring(bits1)
-    bv2 = BitVector.BitVector.from_bitstring(bits2)
+    bv1 = BitVector.from_bitstring(bits1)
+    bv2 = BitVector.from_bitstring(bits2)
     result_bv = (~bv1) + bv2
     assert str(result_bv) == expected, f"Failed on inputs: {bits1}, {bits2}"
 
@@ -41,13 +41,13 @@ def test_addition_consistency(bits1: str, bits2: str) -> None:
         bits2: Bitstring representation for the second operand.
     """
     expected = bits1 + bits2
-    bv1 = BitVector.BitVector.from_bitstring(bits1)
-    bv2 = BitVector.BitVector.from_bitstring(bits2)
+    bv1 = BitVector.from_bitstring(bits1)
+    bv2 = BitVector.from_bitstring(bits2)
 
     added_bv = bv1 + bv2
     assert str(added_bv) == expected
 
-    bv1_copy = BitVector.BitVector.from_bitstring(bits1)
+    bv1_copy = BitVector.from_bitstring(bits1)
     bv1_copy += bv2
     assert str(bv1_copy) == expected
 
@@ -59,7 +59,7 @@ def test_invert_involution(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv = BitVector.BitVector.from_bitstring(bits)
+    bv = BitVector.from_bitstring(bits)
     double_inv = ~(~bv)
     assert str(double_inv) == bits
     assert double_inv == bv
@@ -77,8 +77,8 @@ def test_bitwise_commutativity(bits1: str, bits2: str) -> None:
         bits2: Bitstring representation for the second operand.
     """
     min_len = min(len(bits1), len(bits2))
-    bv1 = BitVector.BitVector.from_bitstring(bits1[:min_len])
-    bv2 = BitVector.BitVector.from_bitstring(bits2[:min_len])
+    bv1 = BitVector.from_bitstring(bits1[:min_len])
+    bv2 = BitVector.from_bitstring(bits2[:min_len])
 
     assert str(bv1 & bv2) == str(bv2 & bv1)
     assert str(bv1 | bv2) == str(bv2 | bv1)
@@ -96,7 +96,7 @@ def test_circular_rotation_reversibility(bits: str, shift: int) -> None:
         bits: Bitstring representation of the test vector.
         shift: Number of positions to rotate.
     """
-    bv = BitVector.BitVector.from_bitstring(bits)
+    bv = BitVector.from_bitstring(bits)
     rotated = bv << shift
     rotated = rotated >> shift
     assert str(rotated) == bits
@@ -114,7 +114,7 @@ def test_reverse_involution(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv = BitVector.BitVector.from_bitstring(bits)
+    bv = BitVector.from_bitstring(bits)
     bv.reverse()
     bv.reverse()
     assert str(bv) == bits
@@ -127,12 +127,12 @@ def test_int_roundtrip(bits: str) -> None:
     Args:
         bits: Bitstring representation of the test vector.
     """
-    bv = BitVector.BitVector.from_bitstring(bits)
+    bv = BitVector.from_bitstring(bits)
     val = int(bv)
     expected_val = int(bits, 2)
     assert val == expected_val
 
-    reconstructed = BitVector.BitVector.from_int(val, size=len(bits))
+    reconstructed = BitVector.from_int(val, size=len(bits))
     assert str(reconstructed) == bits
 
 
@@ -159,11 +159,7 @@ def test_slicing_consistency(bits: str, start: int | None, stop: int | None) -> 
     if start is not None and stop is not None and start > stop:
         start, stop = stop, start
 
-    bv = (
-        BitVector.BitVector.from_bitstring(bits)
-        if bits
-        else BitVector.BitVector(size=0)
-    )
+    bv = BitVector.from_bitstring(bits) if bits else BitVector(size=0)
     sl = slice(start, stop)
     try:
         sliced_bv = bv[sl]

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -5,12 +5,12 @@ import pathlib
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 def test_write_bits_to_stream_object() -> None:
     """Tests writing ASCII bit characters to a text stream object."""
-    bv = BitVector.BitVector.from_bitstring("101100101")
+    bv = BitVector.from_bitstring("101100101")
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == "101100101"
@@ -18,7 +18,7 @@ def test_write_bits_to_stream_object() -> None:
 
 def test_write_to_file_raises_error() -> None:
     """Verifies writing a vector not a multiple of 8 bits raises ValueError."""
-    bv = BitVector.BitVector.from_bitstring("10101")
+    bv = BitVector.from_bitstring("10101")
     with pytest.raises(
         ValueError, match="Only a bit vector whose length is a multiple of 8"
     ):
@@ -27,7 +27,7 @@ def test_write_to_file_raises_error() -> None:
 
 def test_write_to_file() -> None:
     """Tests writing packed bytes to a binary stream and appending."""
-    bv = BitVector.BitVector.from_bitstring("0100000101000010")  # 'AB'
+    bv = BitVector.from_bitstring("0100000101000010")  # 'AB'
     out_stream = io.BytesIO()
     bv.write_to_file(out_stream)
     assert out_stream.getvalue() == b"AB"
@@ -38,7 +38,7 @@ def test_write_to_file() -> None:
 
 def test_write_bits_to_stream_object_empty() -> None:
     """Tests writing an empty bit vector to a stream."""
-    bv = BitVector.BitVector(size=0)
+    bv = BitVector(size=0)
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == ""
@@ -46,7 +46,7 @@ def test_write_bits_to_stream_object_empty() -> None:
 
 def test_write_bits_to_stream_object_not_multiple_of_8() -> None:
     """Tests writing a vector where length is not a multiple of 8."""
-    bv = BitVector.BitVector.from_bitstring("101")
+    bv = BitVector.from_bitstring("101")
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == "101"
@@ -54,7 +54,7 @@ def test_write_bits_to_stream_object_not_multiple_of_8() -> None:
 
 def test_write_bits_to_stream_object_all_zeros() -> None:
     """Tests writing a vector of all 0s."""
-    bv = BitVector.BitVector(size=10)
+    bv = BitVector(size=10)
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == "0000000000"
@@ -62,7 +62,7 @@ def test_write_bits_to_stream_object_all_zeros() -> None:
 
 def test_write_bits_to_stream_object_all_ones() -> None:
     """Tests writing a vector of all 1s."""
-    bv = ~BitVector.BitVector(size=10)
+    bv = ~BitVector(size=10)
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == "1111111111"
@@ -71,7 +71,7 @@ def test_write_bits_to_stream_object_all_ones() -> None:
 def test_write_bits_to_stream_object_large() -> None:
     """Tests writing a vector with more than 64 bits."""
     s = "10101010" * 10  # 80 bits
-    bv = BitVector.BitVector.from_bitstring(s)
+    bv = BitVector.from_bitstring(s)
     fp = io.StringIO()
     bv.write_bits_to_stream_object(fp)
     assert fp.getvalue() == s
@@ -80,39 +80,39 @@ def test_write_bits_to_stream_object_large() -> None:
 def test_from_stream() -> None:
     """Tests reading bytes from an open binary stream."""
     stream = io.BytesIO(b"ABC")
-    bv = BitVector.BitVector.from_stream(stream)
-    assert bv == BitVector.BitVector.from_bytes(b"ABC")
+    bv = BitVector.from_stream(stream)
+    assert bv == BitVector.from_bytes(b"ABC")
 
 
 def test_from_stream_partial() -> None:
     """Tests reading a limited number of bytes from a stream."""
     stream = io.BytesIO(b"ABCDE")
-    bv = BitVector.BitVector.from_stream(stream, num_bytes=2)
-    assert bv == BitVector.BitVector.from_bytes(b"AB")
+    bv = BitVector.from_stream(stream, num_bytes=2)
+    assert bv == BitVector.from_bytes(b"AB")
     assert len(bv) == 16
 
 
 def test_from_stream_empty() -> None:
     """Tests reading from an empty stream."""
     stream = io.BytesIO(b"")
-    bv = BitVector.BitVector.from_stream(stream)
+    bv = BitVector.from_stream(stream)
     assert len(bv) == 0
-    assert bv == BitVector.BitVector(size=0)
+    assert bv == BitVector(size=0)
 
 
 def test_from_stream_negative_num_bytes() -> None:
     """Tests that a negative num_bytes raises a ValueError."""
     stream = io.BytesIO(b"ABC")
     with pytest.raises(ValueError, match="num_bytes must be non-negative"):
-        BitVector.BitVector.from_stream(stream, num_bytes=-1)
+        BitVector.from_stream(stream, num_bytes=-1)
 
 
 def test_from_file_path(tmp_path: pathlib.Path) -> None:
     """Tests reading bytes from a filesystem path."""
     file_path = tmp_path / "test.bin"
     file_path.write_bytes(b"HELLO")
-    bv = BitVector.BitVector.from_file_path(file_path)
-    assert bv == BitVector.BitVector.from_bytes(b"HELLO")
+    bv = BitVector.from_file_path(file_path)
+    assert bv == BitVector.from_bytes(b"HELLO")
 
 
 def test_from_file_path_with_offset_and_limit(
@@ -121,8 +121,8 @@ def test_from_file_path_with_offset_and_limit(
     """Tests reading from a file path with byte offset and byte limit."""
     file_path = tmp_path / "test_slice.bin"
     file_path.write_bytes(b"0123456789")
-    bv = BitVector.BitVector.from_file_path(file_path, offset_bytes=2, num_bytes=4)
-    assert bv == BitVector.BitVector.from_bytes(b"2345")
+    bv = BitVector.from_file_path(file_path, offset_bytes=2, num_bytes=4)
+    assert bv == BitVector.from_bytes(b"2345")
 
 
 def test_from_file_path_negative_offset(
@@ -132,7 +132,7 @@ def test_from_file_path_negative_offset(
     file_path = tmp_path / "test.bin"
     file_path.write_bytes(b"test")
     with pytest.raises(ValueError, match="offset_bytes must be non-negative"):
-        BitVector.BitVector.from_file_path(file_path, offset_bytes=-5)
+        BitVector.from_file_path(file_path, offset_bytes=-5)
 
 
 def test_from_file_path_negative_num_bytes(
@@ -142,13 +142,13 @@ def test_from_file_path_negative_num_bytes(
     file_path = tmp_path / "test.bin"
     file_path.write_bytes(b"test")
     with pytest.raises(ValueError, match="num_bytes must be non-negative"):
-        BitVector.BitVector.from_file_path(file_path, num_bytes=-1)
+        BitVector.from_file_path(file_path, num_bytes=-1)
 
 
 def test_from_file_path_not_found() -> None:
     """Tests that from_file_path raises FileNotFoundError for nonexistent paths."""
     with pytest.raises(FileNotFoundError):
-        BitVector.BitVector.from_file_path("this_file_does_not_exist_12345.bin")
+        BitVector.from_file_path("this_file_does_not_exist_12345.bin")
 
 
 def test_from_file_path_large(tmp_path: pathlib.Path) -> None:
@@ -156,6 +156,6 @@ def test_from_file_path_large(tmp_path: pathlib.Path) -> None:
     file_path = tmp_path / "large.bin"
     data = bytes(i % 256 for i in range(1000))
     file_path.write_bytes(data)
-    bv = BitVector.BitVector.from_file_path(file_path)
-    assert bv == BitVector.BitVector.from_bytes(data)
+    bv = BitVector.from_file_path(file_path)
+    assert bv == BitVector.from_bytes(data)
     assert len(bv) == 8000

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-import BitVector
+from BitVector import BitVector
 
 
 @pytest.mark.parametrize(
@@ -19,13 +19,13 @@ def test_get_bitvector_in_ascii(bitstring: str, expected: str) -> None:
         bitstring: Input binary string.
         expected: The expected ASCII representation string.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     assert bv.get_bitvector_in_ascii() == expected
 
 
 def test_get_bitvector_in_ascii_from_string() -> None:
     """Tests ASCII string conversion when initialized via from_string."""
-    bv = BitVector.BitVector.from_string("hello")
+    bv = BitVector.from_string("hello")
     assert bv.get_bitvector_in_ascii() == "hello"
 
 
@@ -36,7 +36,7 @@ def test_get_bitvector_in_ascii_invalid_length_raises_error(bitstring: str) -> N
     Args:
         bitstring: A bitstring whose length is not a multiple of 8.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match="must be an integral multiple of 8 bits"):
         bv.get_bitvector_in_ascii()
 
@@ -56,13 +56,13 @@ def test_get_bitvector_in_hex(bitstring: str, expected: str) -> None:
         bitstring: Input binary string.
         expected: The expected hexadecimal representation string.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     assert bv.get_bitvector_in_hex() == expected
 
 
 def test_get_bitvector_in_hex_from_hex() -> None:
     """Tests hexadecimal string conversion when initialized via from_hex."""
-    bv = BitVector.BitVector.from_hex("68656c6c6f")
+    bv = BitVector.from_hex("68656c6c6f")
     assert bv.get_bitvector_in_hex() == "68656c6c6f"
 
 
@@ -73,7 +73,7 @@ def test_get_bitvector_in_hex_invalid_length_raises_error(bitstring: str) -> Non
     Args:
         bitstring: A bitstring whose length is not a multiple of 4.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     with pytest.raises(ValueError, match="must be an integral multiple of 4 bits"):
         bv.get_bitvector_in_hex()
 
@@ -92,11 +92,11 @@ def test_str_representation(bitstring: str, expected: str) -> None:
         bitstring: Input binary string.
         expected: The expected binary string representation.
     """
-    bv = BitVector.BitVector.from_bitstring(bitstring)
+    bv = BitVector.from_bitstring(bitstring)
     assert str(bv) == expected
 
 
 def test_str_representation_from_hex() -> None:
     """Tests the string (__str__) representation when initialized via from_hex."""
-    bv = BitVector.BitVector.from_hex("f")
+    bv = BitVector.from_hex("f")
     assert str(bv) == "1111"


### PR DESCRIPTION
Replace over 290 redundant qualified BitVector.BitVector references across 12 test modules with direct BitVector imports. Preserve module-path string literals used in unittest.mock patching (e.g., BitVector.BitVector.secrets.randbits).

#206 - **Theme 3** - **Direct Class Imports**: Standardize imports across tests/ to from BitVector import BitVector, removing over 100 redundant BitVector.BitVector qualified references.